### PR TITLE
5. Proxy GraphQL request from React to Shopify

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -11,7 +11,7 @@ class VerifyCsrfToken extends Middleware
      *
      * @var array
      */
-    protected $except = [
+    protected $except = ['graphql'
         //
     ];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,10 @@
     "packages": {
         "": {
             "dependencies": {
+                "@apollo/client": "^3.3.16",
                 "@shopify/app-bridge": "^2.0.2",
                 "@shopify/app-bridge-utils": "^2.0.2",
+                "graphql": "^15.5.0",
                 "react-dom": "^17.0.2"
             },
             "devDependencies": {
@@ -16,6 +18,44 @@
                 "lodash": "^4.17.19",
                 "postcss": "^8.1.14"
             }
+        },
+        "node_modules/@apollo/client": {
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.16.tgz",
+            "integrity": "sha512-EPTiNpmiU6/vvxpl4lXWQDqS3YddweC1sh/ewCuVP9IK0+xlVGb5vR1yhM/7T3PIJqwz52dGpZyJskmbTfENfQ==",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.0.0",
+                "@types/zen-observable": "^0.8.0",
+                "@wry/context": "^0.6.0",
+                "@wry/equality": "^0.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graphql-tag": "^2.12.0",
+                "hoist-non-react-statics": "^3.3.2",
+                "optimism": "^0.15.0",
+                "prop-types": "^15.7.2",
+                "symbol-observable": "^2.0.0",
+                "ts-invariant": "^0.7.0",
+                "tslib": "^1.10.0",
+                "zen-observable": "^0.8.14"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0",
+                "react": "^16.8.0 || ^17.0.0",
+                "subscriptions-transport-ws": "^0.9.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "subscriptions-transport-ws": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@apollo/client/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.12.13",
@@ -1401,6 +1441,14 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@graphql-typed-document-node/core": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+            "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -2030,6 +2078,11 @@
             "integrity": "sha512-y9Pw8IK50OqFRDpdI9Is29KlWiENVW9FDvlTmGHelvTfR2brYFJbsClvulZfeq6YKacFrDsG9a39w0kJZdHLaw==",
             "dev": true
         },
+        "node_modules/@types/zen-observable": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+            "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg=="
+        },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
@@ -2210,6 +2263,39 @@
                 "webpack-dev-server": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@wry/context": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+            "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@wry/equality": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.4.0.tgz",
+            "integrity": "sha512-DxN/uawWfhRbgYE55zVCPOoe+jvsQ4m7PT1Wlxjyb/LCCLuU1UsucV2BbCxFAX8bjcSueFBbB5Qfj1Zfe8e7Fw==",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@wry/trie": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+            "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@xtuc/ieee754": {
@@ -5004,8 +5090,7 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.12",
@@ -5432,6 +5517,28 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
         },
+        "node_modules/graphql": {
+            "version": "15.5.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+            "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/graphql-tag": {
+            "version": "2.12.4",
+            "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",
+            "integrity": "sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+            }
+        },
         "node_modules/growly": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -5637,6 +5744,14 @@
                 "hash.js": "^1.0.3",
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "dependencies": {
+                "react-is": "^16.7.0"
             }
         },
         "node_modules/hpack.js": {
@@ -7838,6 +7953,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/optimism": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.15.0.tgz",
+            "integrity": "sha512-KLKl3Kb7hH++s9ewRcBhmfpXgXF0xQ+JZ3xQFuPjnoT6ib2TDmYyVkKENmGxivsN2G3VRxpXuauCkB4GYOhtPw==",
+            "dependencies": {
+                "@wry/context": "^0.6.0",
+                "@wry/trie": "^0.3.0"
             }
         },
         "node_modules/os-browserify": {
@@ -10052,6 +10176,16 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "node_modules/prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            }
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -10234,6 +10368,11 @@
             "peerDependencies": {
                 "react": "17.0.2"
             }
+        },
+        "node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/readable-stream": {
             "version": "2.3.7",
@@ -11506,6 +11645,14 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/symbol-observable": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+            "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/tapable": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
@@ -11794,11 +11941,21 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/ts-invariant": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+            "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/tslib": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-            "dev": true
+            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         },
         "node_modules/tty-browserify": {
             "version": "0.0.0",
@@ -12753,9 +12910,41 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/zen-observable": {
+            "version": "0.8.15",
+            "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+            "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
         }
     },
     "dependencies": {
+        "@apollo/client": {
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.16.tgz",
+            "integrity": "sha512-EPTiNpmiU6/vvxpl4lXWQDqS3YddweC1sh/ewCuVP9IK0+xlVGb5vR1yhM/7T3PIJqwz52dGpZyJskmbTfENfQ==",
+            "requires": {
+                "@graphql-typed-document-node/core": "^3.0.0",
+                "@types/zen-observable": "^0.8.0",
+                "@wry/context": "^0.6.0",
+                "@wry/equality": "^0.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graphql-tag": "^2.12.0",
+                "hoist-non-react-statics": "^3.3.2",
+                "optimism": "^0.15.0",
+                "prop-types": "^15.7.2",
+                "symbol-observable": "^2.0.0",
+                "ts-invariant": "^0.7.0",
+                "tslib": "^1.10.0",
+                "zen-observable": "^0.8.14"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
         "@babel/code-frame": {
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -13896,6 +14085,12 @@
             "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
             "dev": true
         },
+        "@graphql-typed-document-node/core": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+            "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+            "requires": {}
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -14452,6 +14647,11 @@
             "integrity": "sha512-y9Pw8IK50OqFRDpdI9Is29KlWiENVW9FDvlTmGHelvTfR2brYFJbsClvulZfeq6YKacFrDsG9a39w0kJZdHLaw==",
             "dev": true
         },
+        "@types/zen-observable": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+            "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg=="
+        },
         "@webassemblyjs/ast": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
@@ -14620,6 +14820,30 @@
             "integrity": "sha512-0qXvpeYO6vaNoRBI52/UsbcaBydJCggoBBnIo/ovQQdn6fug0BgwsjorV1hVS7fMqGVTZGcVxv8334gjmbj5hw==",
             "dev": true,
             "requires": {}
+        },
+        "@wry/context": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+            "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
+            "requires": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "@wry/equality": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.4.0.tgz",
+            "integrity": "sha512-DxN/uawWfhRbgYE55zVCPOoe+jvsQ4m7PT1Wlxjyb/LCCLuU1UsucV2BbCxFAX8bjcSueFBbB5Qfj1Zfe8e7Fw==",
+            "requires": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "@wry/trie": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+            "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+            "requires": {
+                "tslib": "^2.1.0"
+            }
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -16871,8 +17095,7 @@
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "fastest-levenshtein": {
             "version": "1.0.12",
@@ -17184,6 +17407,19 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
         },
+        "graphql": {
+            "version": "15.5.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+            "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+        },
+        "graphql-tag": {
+            "version": "2.12.4",
+            "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",
+            "integrity": "sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==",
+            "requires": {
+                "tslib": "^2.1.0"
+            }
+        },
         "growly": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -17342,6 +17578,14 @@
                 "hash.js": "^1.0.3",
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "requires": {
+                "react-is": "^16.7.0"
             }
         },
         "hpack.js": {
@@ -19017,6 +19261,15 @@
                 "is-wsl": "^2.1.1"
             }
         },
+        "optimism": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.15.0.tgz",
+            "integrity": "sha512-KLKl3Kb7hH++s9ewRcBhmfpXgXF0xQ+JZ3xQFuPjnoT6ib2TDmYyVkKENmGxivsN2G3VRxpXuauCkB4GYOhtPw==",
+            "requires": {
+                "@wry/context": "^0.6.0",
+                "@wry/trie": "^0.3.0"
+            }
+        },
         "os-browserify": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -20669,6 +20922,16 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            }
+        },
         "proxy-addr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -20809,6 +21072,11 @@
                 "object-assign": "^4.1.1",
                 "scheduler": "^0.20.2"
             }
+        },
+        "react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "readable-stream": {
             "version": "2.3.7",
@@ -21856,6 +22124,11 @@
                 "util.promisify": "~1.0.0"
             }
         },
+        "symbol-observable": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+            "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
+        },
         "tapable": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
@@ -22075,11 +22348,18 @@
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
             "dev": true
         },
+        "ts-invariant": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+            "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
+            "requires": {
+                "tslib": "^2.1.0"
+            }
+        },
         "tslib": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-            "dev": true
+            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         },
         "tty-browserify": {
             "version": "0.0.0",
@@ -22791,6 +23071,11 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
+        },
+        "zen-observable": {
+            "version": "0.8.15",
+            "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+            "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
         "postcss": "^8.1.14"
     },
     "dependencies": {
+        "@apollo/client": "^3.3.16",
         "@shopify/app-bridge": "^2.0.2",
         "@shopify/app-bridge-utils": "^2.0.2",
+        "graphql": "^15.5.0",
         "react-dom": "^17.0.2"
     }
 }

--- a/resources/js/react/App.jsx
+++ b/resources/js/react/App.jsx
@@ -1,16 +1,31 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import createApp from "@shopify/app-bridge";
-import { getSessionToken } from "@shopify/app-bridge-utils"
+import {authenticatedFetch} from "@shopify/app-bridge-utils"
+import {ApolloClient, gql, HttpLink, InMemoryCache} from '@apollo/client';
+
+const TEST_QUERY = gql`query { shop {name} }`;
 
 function App({host, apiKey}) {
     const app = createApp({
         apiKey: apiKey,
         host: host
     });
-    getSessionToken(app).then((token) => {
-        console.log(token);
+
+    const client = new ApolloClient({
+        link: new HttpLink({
+            credentials: 'same-origin',
+            fetch: authenticatedFetch(app),
+            uri: '/graphql'
+        }),
+        cache: new InMemoryCache()
     });
+
+    client
+        .query({
+            query: TEST_QUERY
+        })
+        .then(result => console.log(result));
 
     return (
         <h1>Hello React</h1>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
 use Shopify\Context;
 use Shopify\Auth\OAuth;
+use Shopify\Utils;
 
 /*
 |--------------------------------------------------------------------------
@@ -35,4 +36,9 @@ Route::get('/auth/callback', function (Request $request) {
     $host = $request->query('host');
     $shop = $request->query('shop');
     return redirect("?" . http_build_query(['host' => $host, 'shop' => $shop]));
+});
+
+Route::post('/graphql', function (Request $request) {
+    $result = Utils::graphqlProxy($request->header(), $request->cookie(), $request->getContent());
+    return response($result->getDecodedBody())->withHeaders($result->getHeaders());
 });

--- a/tests/Feature/BaseTestCase.php
+++ b/tests/Feature/BaseTestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Tests\Feature;
+
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Client\ClientInterface;
+use Shopify\Clients\HttpClientFactory;
+use Shopify\Context;
+use Tests\TestCase;
+
+class BaseTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Make sure that we don't make requests in tests by mistake
+        $factory = $this->createMock(HttpClientFactory::class);
+        $factory->expects($this->any())
+            ->method('client');
+        Context::$HTTP_CLIENT_FACTORY = $factory;
+    }
+
+
+    protected function mockClient(): ClientInterface|MockObject
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $factory = $this->createMock(HttpClientFactory::class);
+        $factory->expects($this->any())
+            ->method('client')
+            ->willReturn($client);
+        Context::$HTTP_CLIENT_FACTORY = $factory;
+        return $client;
+    }
+}

--- a/tests/Feature/ProxyGraphqlTest.php
+++ b/tests/Feature/ProxyGraphqlTest.php
@@ -1,0 +1,99 @@
+<?php
+
+
+namespace Tests\Feature;
+
+
+use Firebase\JWT\JWT;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Shopify\Auth\Session;
+use Shopify\Context;
+
+class ProxyGraphqlTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    public function testGraphqlProxyFetchesDataWithJWT()
+    {
+        $testGraphqlQuery = '{"variables":{},"query":"{\n shop {\n name\n __typename\n }\n}\n"}';
+
+        $testGraphqlResponse = [
+            "data" => [
+                "shop" => [
+                    "name" => "Shoppity Shop",
+                ],
+            ],
+        ];
+
+        $sessionId = 'test-shop.myshopify.com_42';
+        Context::$IS_EMBEDDED_APP = true;
+        $session = new Session(
+            id: $sessionId,
+            shop: 'test-shop.myshopify.io',
+            isOnline: true,
+            state: '1234',
+        );
+
+
+        $session->setAccessToken('token');
+
+        $this->assertTrue(Context::$SESSION_STORAGE->storeSession($session));
+        $this->assertEquals($session, Context::$SESSION_STORAGE->loadSession('test-shop.myshopify.com_42'));
+
+        $client = $this->mockClient();
+
+        $client->expects($this->exactly(1))
+            ->method('sendRequest')
+            ->with(
+                $this->callback(
+                    function ($request) use ($testGraphqlQuery) {
+                        return
+                            $request->getUri(
+                            ) == "https://test-shop.myshopify.io/admin/api/" . Context::$API_VERSION . '/graphql.json'
+                            && $request->getBody()->getContents() == $testGraphqlQuery;
+                    }
+                )
+            )
+            ->willReturn(
+                new Response(
+                    status: 200,
+                    headers: ["response-header" => "header-value"],
+                    body: json_encode($testGraphqlResponse)
+                )
+            );
+        $token = $this->encodeJwtPayload();
+
+        $response = $this->call(
+            method: 'POST',
+            uri: "/graphql",
+            server: $this->transformHeadersToServerVars(['Authorization' => "Bearer $token"]),
+            content: $testGraphqlQuery
+        );
+
+        $response->assertStatus(200);
+        $response->assertExactJson($testGraphqlResponse);
+        $response->assertHeader('response-header', 'header-value');
+    }
+
+
+    private function encodeJwtPayload(): string
+    {
+        $payload = [
+            "iss" => "https://test-shop.myshopify.com/admin",
+            "dest" => "https://test-shop.myshopify.com",
+            "aud" => "api-key-123",
+            "sub" => "42",
+            "exp" => strtotime('+5 minutes'),
+            "nbf" => 1591764998,
+            "iat" => 1591764998,
+            "jti" => "f8912129-1af6-4cad-9ca3-76b0f7621087",
+            "sid" => "aaea182f2732d44c23057c0fea584021a4485b2bd25d3eb7fd349313ad24c685"
+        ];
+        return JWT::encode($payload, Context::$API_SECRET_KEY);
+    }
+
+
+}
+
+


### PR DESCRIPTION
### app-bridge-react and react-apollo
The plan was initially to mimic the implementation in https://github.com/Shopify/shopify-app-node/blob/master/pages/_app.js. However, `app-bridge-react` and `react-apollo` are not compatible with React 17, which is what Laravel is using. As a result I have opted to using Apollo client directly.

### Potential issue with graphql proxy
Should be fixed when https://github.com/Shopify/shopify-php-api/pull/74 is merged
<details>
<summary>
Query variables get transformed from a JSON object to an array.
</summary>

- Requests coming from Apollo to the App come as a string for example: `{"variables":{},"query":"{\n  shop {\n    name\n    __typename\n  }\n}\n"}`
- In `Utils::graphqlProxy` that payload is decoded with the flag for associative array result `json_decode($rawBody, true)`
- When we try to re-encode the body again inside `GraphQ->query` it gets encoded as `{"variables":[],"query":"{\n  shop {\n    name\n    __typename\n  }\n}\n"}`
</details>

### Todo:
- [x] Tests
- [x] In the Shopify App Library debug issue with graphQlProxy
- [ ] Add `X-Shopify-API-Request-Failure-Reauthorize-Url`
