### PR TITLE
Adding APP_UNINSTALLED webhook

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -11,7 +11,8 @@ class VerifyCsrfToken extends Middleware
      *
      * @var array
      */
-    protected $except = ['graphql'
-        //
+    protected $except = [
+        'graphql',
+        'webhooks',
     ];
 }

--- a/app/Lib/Handlers/AppUninstalled.php
+++ b/app/Lib/Handlers/AppUninstalled.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lib\Handlers;
+
+use Illuminate\Support\Facades\Log;
+use Shopify\Webhooks\Handler;
+use App\Models\Session;
+
+class AppUninstalled implements Handler
+{
+    public function handle(string $topic, string $shop, array $body): void
+    {
+        Log::debug("App was uninstalled from $shop - removing all sessions");
+        Session::where('shop', $shop)->delete();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,9 +3,12 @@
 namespace App\Providers;
 
 use App\Lib\DbSessionStorage;
+use App\Lib\Handlers\AppUninstalled;
 use Illuminate\Support\ServiceProvider;
-use Shopify\Context;
 use Illuminate\Support\Facades\URL;
+use Shopify\Context;
+use Shopify\Webhooks\Registry;
+use Shopify\Webhooks\Topics;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -36,5 +39,7 @@ class AppServiceProvider extends ServiceProvider
         );
 
         URL::forceScheme('https');
+
+        Registry::addHandler(Topics::APP_UNINSTALLED, new AppUninstalled());
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,8 +7,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Log;
 use Shopify\Context;
-use Shopify\Auth\OAuth;
 use Shopify\Utils;
+use Shopify\Auth\OAuth;
+use Shopify\Clients\HttpHeaders;
+use Shopify\Webhooks\Registry;
+use Shopify\Webhooks\Topics;
 
 /*
 |--------------------------------------------------------------------------
@@ -82,17 +85,45 @@ Route::get('/login', function (Request $request) {
 });
 
 Route::get('/auth/callback', function (Request $request) {
-    Log::info($request->cookie(OAuth::SESSION_ID_COOKIE_NAME));
-    OAuth::callback(
-        [OAuth::SESSION_ID_COOKIE_NAME => $request->cookie(OAuth::SESSION_ID_COOKIE_NAME)],
-        $request->query()
-    );
+    $session = OAuth::callback($request->cookie(), $request->query());
+
     $host = $request->query('host');
     $shop = Utils::sanitizeShopDomain($request->query('shop'));
+
+    $response = Registry::register(
+        path: '/webhooks',
+        topic: Topics::APP_UNINSTALLED,
+        shop: $shop,
+        accessToken: $session->getAccessToken(),
+    );
+    if ($response->isSuccess()) {
+        Log::debug("Registered APP_UNINSTALLED webhook for shop $shop");
+    } else {
+        Log::error(
+            "Failed to register APP_UNINSTALLED webhook for shop $shop with response body: " .
+            print_r($response->getBody(), true)
+        );
+    }
+
     return redirect("?" . http_build_query(['host' => $host, 'shop' => $shop]));
 });
 
 Route::post('/graphql', function (Request $request) {
     $result = Utils::graphqlProxy($request->header(), $request->cookie(), $request->getContent());
     return response($result->getDecodedBody())->withHeaders($result->getHeaders());
+});
+
+Route::post('/webhooks', function (Request $request) {
+    try {
+        $topic = $request->header(HttpHeaders::X_SHOPIFY_TOPIC, '');
+
+        $response = Registry::process($request->header(), $request->getContent());
+        if (!$response->isSuccess()) {
+            Log::error("Failed to process '$topic' webhook: {$response->getErrorMessage()}");
+            return response()->json(['message' => "Failed to process '$topic' webhook"], 500);
+        }
+    } catch (\Exception $e) {
+        Log::error("Got an exception when handling '$topic' webhook: {$e->getMessage()}");
+        return response()->json(['message' => "Got an exception when handling '$topic' webhook"], 500);
+    }
 });

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Shopify\Clients\HttpHeaders;
+use Shopify\Context;
+use Shopify\Webhooks\Handler;
+use Shopify\Webhooks\Registry;
+use Shopify\Webhooks\Topics;
+
+class WebhookTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private string $domain = "test-shop.myshopify.io";
+
+    public function testWebhookIsProcessed()
+    {
+        $shop = $this->domain;
+        $topic = Topics::APP_UNINSTALLED;
+        $body = ['dummy' => 'data'];
+
+        /** @var MockObject|Handler */
+        $mock = $this->getMockBuilder(Handler::class)
+            ->getMock();
+        $mock->expects($this->once())
+            ->method('handle')
+            ->with($topic, $shop, $body);
+
+        Registry::addHandler($topic, $mock);
+
+        $hmac = base64_encode(hash_hmac('sha256', json_encode($body), Context::$API_SECRET_KEY, true));
+        $response = $this
+            ->json(
+                method: 'POST',
+                uri: "/webhooks",
+                data: $body,
+                headers: [
+                    HttpHeaders::X_SHOPIFY_TOPIC => $topic,
+                    HttpHeaders::X_SHOPIFY_DOMAIN => $shop,
+                    HttpHeaders::X_SHOPIFY_HMAC => $hmac,
+                ],
+            );
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Now that we have OAuth working, we can add a webhook handler for the `APP_UNINSTALLED` event, which will delete all of a shop's sessions in the database to make sure that shop goes through OAuth again if it ever reinstalls the app.

### WHAT is this pull request doing?

Using the library to handle the uninstallation webhook, and wiping all sessions for the shop when that happens, to ensure it is not considered installed in the future.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
