### PR TITLE
Adding example REST route

### DIFF
--- a/tests/Feature/ProxyGraphqlTest.php
+++ b/tests/Feature/ProxyGraphqlTest.php
@@ -7,6 +7,7 @@ use App\Http\Middleware\EnsureShopifySession;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Shopify\Auth\OAuth;
 use Shopify\Auth\Session;
 use Shopify\Context;
 
@@ -14,9 +15,22 @@ class ProxyGraphqlTest extends BaseTestCase
 {
     use RefreshDatabase;
 
-    public function testGraphqlProxyFetchesDataWithJWT()
+    public function appTypeProvider()
     {
-        $testGraphqlQuery = '{"variables":{},"query":"{\n shop {\n name\n __typename\n }\n}\n"}';
+        return [
+            'embedded app' => [true],
+            'non-embedded app' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider appTypeProvider
+     */
+    public function testGraphqlProxyFetchesDataWithJWT(bool $isEmbedded)
+    {
+        Context::$IS_EMBEDDED_APP = $isEmbedded;
+
+        $testGraphqlQuery = '{"variables":[],"query":"{\n shop {\n name\n __typename\n }\n}\n"}';
 
         $testGraphqlResponse = [
             "data" => [
@@ -26,8 +40,7 @@ class ProxyGraphqlTest extends BaseTestCase
             ],
         ];
 
-        $sessionId = 'test-shop.myshopify.com_42';
-        Context::$IS_EMBEDDED_APP = true;
+        $sessionId = $isEmbedded ? 'test-shop.myshopify.com_42' : 'cookie-session-id';
         $session = new Session(
             id: $sessionId,
             shop: 'test-shop.myshopify.io',
@@ -38,7 +51,7 @@ class ProxyGraphqlTest extends BaseTestCase
         $session->setAccessToken('token');
 
         $this->assertTrue(Context::$SESSION_STORAGE->storeSession($session));
-        $this->assertEquals($session, Context::$SESSION_STORAGE->loadSession('test-shop.myshopify.com_42'));
+        $this->assertEquals($session, Context::$SESSION_STORAGE->loadSession($sessionId));
 
         $graphqlUrl = "https://test-shop.myshopify.io/admin/api/unstable/graphql.json";
 
@@ -72,20 +85,28 @@ class ProxyGraphqlTest extends BaseTestCase
                     body: json_encode($testGraphqlResponse),
                 ),
             );
-        $token = $this->encodeJwtPayload();
 
-        $response = $this->call(
+        $request = $this;
+        $headers = [];
+        if ($isEmbedded) {
+            $token = $this->encodeJwtPayload();
+            $headers['Authorization'] = "Bearer $token";
+        } else {
+            $request->withCredentials()
+                ->withCookie(OAuth::SESSION_ID_COOKIE_NAME, $sessionId);
+        }
+
+        $response = $request->json(
             method: 'POST',
             uri: "/graphql",
-            server: $this->transformHeadersToServerVars(['Authorization' => "Bearer $token"]),
-            content: $testGraphqlQuery
+            headers: $headers,
+            data: json_decode($testGraphqlQuery, true),
         );
 
         $response->assertStatus(200);
         $response->assertExactJson($testGraphqlResponse);
         $response->assertHeader('response-header', 'header-value');
     }
-
 
     private function encodeJwtPayload(): string
     {

--- a/tests/Feature/RestExampleTest.php
+++ b/tests/Feature/RestExampleTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use Firebase\JWT\JWT;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Shopify\Auth\OAuth;
+use Shopify\Auth\Session;
+use Shopify\Context;
+
+class RestExampleTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    public function appTypeProvider()
+    {
+        return [
+            'embedded app' => [true],
+            'non-embedded app' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider appTypeProvider
+     */
+    public function testExampleRestRequest(bool $isEmbedded)
+    {
+        Context::$IS_EMBEDDED_APP = $isEmbedded;
+
+        $sessionId = $isEmbedded ? 'test-shop.myshopify.io_42' : 'cookie-session-id';
+        $session = new Session(
+            id: $sessionId,
+            shop: 'test-shop.myshopify.io',
+            isOnline: true,
+            state: '1234',
+        );
+        $session->setScope('write_products');
+        $session->setAccessToken('token');
+
+        $this->assertTrue(Context::$SESSION_STORAGE->storeSession($session));
+
+        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/unstable/graphql.json";
+        $restUrl = "https://test-shop.myshopify.io/admin/api/unstable/products.json?limit=5";
+        $restResponse = [
+            'data' => [
+                'products' => [
+                    'name' => 'Test Product',
+                    'amount' => 1,
+                ],
+            ]
+        ];
+
+        $client = $this->mockClient();
+        $client->expects($this->exactly(2))
+            ->method('sendRequest')
+            ->withConsecutive(
+                [$this->callback(fn($request) => $request->getUri() == $graphqlUrl)],
+                [$this->callback(fn($request) => $request->getUri() == $restUrl)],
+            )
+            ->willReturnOnConsecutiveCalls(
+                new Response(status: 200),
+                new Response(status: 200, body: json_encode($restResponse)),
+            );
+
+        $request = $this;
+        $headers = [];
+        if ($isEmbedded) {
+            $token = $this->encodeJwtPayload();
+            $headers['Authorization'] = "Bearer $token";
+        } else {
+            $request->withCredentials()
+                ->withCookie(OAuth::SESSION_ID_COOKIE_NAME, $sessionId);
+        }
+
+        $response = $request->json(
+            method: 'GET',
+            uri: "/rest-example",
+            headers: $headers,
+        );
+
+        $response->assertStatus(200);
+        $response->assertExactJson($restResponse);
+    }
+
+    private function encodeJwtPayload(): string
+    {
+        $payload = [
+            "iss" => "https://test-shop.myshopify.io/admin",
+            "dest" => "https://test-shop.myshopify.io",
+            "aud" => "api-key-123",
+            "sub" => "42",
+            "exp" => strtotime('+5 minutes'),
+            "nbf" => 1591764998,
+            "iat" => 1591764998,
+            "jti" => "f8912129-1af6-4cad-9ca3-76b0f7621087",
+            "sid" => "aaea182f2732d44c23057c0fea584021a4485b2bd25d3eb7fd349313ad24c685"
+        ];
+        return JWT::encode($payload, Context::$API_SECRET_KEY);
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Our app is currently showcasing how to make GraphQL requests using the proxy, but not using the clients we provide. To demonstrate the scenario, we could add an endpoint to our API that shows how requests can be made.

### WHAT is this pull request doing?

Adding a very simple REST example, which just fetches a few products and returns those, to display how one might be able to do that.

While adding a test for that, I noticed we didn't have a test for the GraphQL proxy in non-embedded apps, so I just added it here since the data provider works exactly the same as the new test.

## Checklist

- [x] I have added/updated tests for this change
