### PR TITLE
Trimming checks in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,14 +21,6 @@ Fixes #0000 <!-- link to issue if one exists -->
   Before / after screenshots appreciated for UI changes, if applicable.
 -->
 
-## Type of change
-
-- [ ] Patch: Bug (non-breaking change which fixes an issue)
-- [ ] Minor: New feature (non-breaking change which adds functionality)
-- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
-
 ## Checklist
 
-- [ ] I have added a changelog entry, prefixed by the type of change noted above
 - [ ] I have added/updated tests for this change


### PR DESCRIPTION
I'm just trimming the PR template a little, since we had checks for version bumps and changelogs, which don't really apply to this repo.