### PR TITLE
Allow protocol in HOST env var

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,7 +34,7 @@ class AppServiceProvider extends ServiceProvider
             apiKey: env('SHOPIFY_API_KEY'),
             apiSecretKey: env('SHOPIFY_API_SECRET'),
             scopes: env('SCOPES'),
-            hostName: env('HOST'),
+            hostName: str_replace('https://', '', env('HOST')),
             sessionStorage: new DbSessionStorage()
         );
 


### PR DESCRIPTION
The CLI fills in the `HOST` env var with the `https://` part, which breaks the app. Since the library doesn't allow the protocol, we can simply parse that part out if it is present, which works well for non-CLI apps as well as it makes the setup less error-prone.