### PR TITLE
Replace / endpoint with fallback

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,7 @@ use Shopify\Webhooks\Topics;
 |
 */
 
-Route::get('/', function (Request $request) {
+Route::fallback(function (Request $request) {
     $shop = Utils::sanitizeShopDomain($request->query('shop'));
     $host = $request->query('host');
     $appInstalled = Session::where('shop', $shop)->exists();

--- a/tests/Feature/RootTest.php
+++ b/tests/Feature/RootTest.php
@@ -33,4 +33,20 @@ class RootTest extends TestCase
         $response->assertStatus(200);
         $response->assertViewIs('react');
     }
+
+    public function testUncaughtRequestsTriggerRouteBehaviour()
+    {
+        $session = new Session(
+            "test-session-id",
+            "test-shop.myshopify.io",
+            false,
+            "test-session-state"
+        );
+
+        Context::$SESSION_STORAGE->storeSession($session);
+
+        $response = $this->get("/not-a-real-endpoint?shop=test-shop.myshopify.io");
+        $response->assertStatus(200);
+        $response->assertViewIs('react');
+    }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Since we're going for a client-side application here, we should make sure that all uncaught requests simply load the app app again instead of showing a 404, so we don't accidentally break out of the React app.

### WHAT is this pull request doing?

Replacing the `GET /` endpoint with `Route::fallback` which works as a catch-all if no routes matched.

## Checklist

- [x] I have added/updated tests for this change
