### PR TITLE
Add mandatory GDPR webhook handler stubs

### DIFF
--- a/web/app/Lib/Handlers/Gdpr/CustomersDataRequest.php
+++ b/web/app/Lib/Handlers/Gdpr/CustomersDataRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lib\Handlers\Gdpr;
+
+use Illuminate\Support\Facades\Log;
+use Shopify\Webhooks\Handler;
+
+/**
+ * Customers can request their data from a store owner. When this happens,
+ * Shopify invokes this webhook.
+ *
+ * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
+ */
+class CustomersDataRequest implements Handler
+{
+    public function handle(string $topic, string $shop, array $body): void
+    {
+        Log::debug("Handling GDPR customer data request for $shop");
+        // Payload has the following shape:
+        // {
+        //   "shop_id": 954889,
+        //   "shop_domain": "{shop}.myshopify.com",
+        //   "orders_requested": [
+        //     299938,
+        //     280263,
+        //     220458
+        //   ],
+        //   "customer": {
+        //     "id": 191167,
+        //     "email": "john@example.com",
+        //     "phone": "555-625-1199"
+        //   },
+        //   "data_request": {
+        //     "id": 9999
+        //   }
+        // }
+    }
+}

--- a/web/app/Lib/Handlers/Gdpr/CustomersRedact.php
+++ b/web/app/Lib/Handlers/Gdpr/CustomersRedact.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lib\Handlers\Gdpr;
+
+use Illuminate\Support\Facades\Log;
+use Shopify\Webhooks\Handler;
+
+/**
+ * Store owners can request that data is deleted on behalf of a customer. When
+ * this happens, Shopify invokes this webhook.
+ *
+ * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-redact
+ */
+class CustomersRedact implements Handler
+{
+    public function handle(string $topic, string $shop, array $body): void
+    {
+        Log::debug("Handling GDPR customer redaction request for $shop");
+        // Payload has the following shape:
+        // {
+        //   "shop_id": 954889,
+        //   "shop_domain": "{shop}.myshopify.com",
+        //   "customer": {
+        //     "id": 191167,
+        //     "email": "john@example.com",
+        //     "phone": "555-625-1199"
+        //   },
+        //   "orders_to_redact": [
+        //     299938,
+        //     280263,
+        //     220458
+        //   ]
+        // }
+    }
+}

--- a/web/app/Lib/Handlers/Gdpr/ShopRedact.php
+++ b/web/app/Lib/Handlers/Gdpr/ShopRedact.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lib\Handlers\Gdpr;
+
+use Illuminate\Support\Facades\Log;
+use Shopify\Webhooks\Handler;
+
+/**
+ * 48 hours after a store owner uninstalls your app, Shopify invokes this
+ * webhook.
+ *
+ * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#shop-redact
+ */
+class ShopRedact implements Handler
+{
+    public function handle(string $topic, string $shop, array $body): void
+    {
+        Log::debug("Handling GDPR shop redaction request for $shop");
+        // Payload has the following shape:
+        // {
+        //   "shop_id": 954889,
+        //   "shop_domain": "{shop}.myshopify.com"
+        // }
+    }
+}

--- a/web/app/Providers/AppServiceProvider.php
+++ b/web/app/Providers/AppServiceProvider.php
@@ -4,7 +4,9 @@ namespace App\Providers;
 
 use App\Lib\DbSessionStorage;
 use App\Lib\Handlers\AppUninstalled;
-use Illuminate\Support\Facades\Config;
+use App\Lib\Handlers\Gdpr\CustomersDataRequest;
+use App\Lib\Handlers\Gdpr\CustomersRedact;
+use App\Lib\Handlers\Gdpr\ShopRedact;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\URL;
 use Shopify\Context;
@@ -45,5 +47,19 @@ class AppServiceProvider extends ServiceProvider
         URL::forceScheme('https');
 
         Registry::addHandler(Topics::APP_UNINSTALLED, new AppUninstalled());
+
+        /*
+         * This sets up the mandatory GDPR webhooks. You’ll need to fill in the endpoint to be used by your app in the
+         * “GDPR mandatory webhooks” section in the “App setup” tab, and customize the code when you store customer data
+         * in the handlers being registered below.
+         *
+         * More details can be found on shopify.dev:
+         * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks
+         *
+         * Note that you'll only receive these webhooks if your app has the relevant scopes as detailed in the docs.
+         */
+        Registry::addHandler('CUSTOMERS_DATA_REQUEST', new CustomersDataRequest());
+        Registry::addHandler('CUSTOMERS_REDACT', new CustomersRedact());
+        Registry::addHandler('SHOP_REDACT', new ShopRedact());
     }
 }

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -86,7 +86,7 @@ Route::get('/api/auth/callback', function (Request $request) {
     } else {
         Log::error(
             "Failed to register APP_UNINSTALLED webhook for shop $shop with response body: " .
-            print_r($response->getBody(), true)
+                print_r($response->getBody(), true)
         );
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify apps are required to implement a few mandatory GDPR webhooks in order to be approved for the App Store.

### WHAT is this pull request doing?

Adding handlers for the GDPR events while setting up the Shopify lib in `AppServiceProvider`. This will trigger some handler stubs that partners can implement depending on their needs.