### PR TITLE
Change license field to UNLICENSED

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shopify-app-template-php",
   "version": "1.0.0",
-  "license": "MIT",
+  "license": "UNLICENSED",
   "scripts": {
     "shopify": "shopify",
     "build": "shopify app build",

--- a/web/composer.json
+++ b/web/composer.json
@@ -3,7 +3,7 @@
     "type": "project",
     "description": "The Laravel Framework.",
     "keywords": ["framework", "laravel"],
-    "license": "MIT",
+    "license": "UNLICENSED",
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1",
         "doctrine/dbal": "^3.1",


### PR DESCRIPTION
### WHY are these changes introduced?

To make the `"license"` field in the `package.json` file consistent with those in `shopify-app-template-*`

### WHAT is this pull request doing?

Change the `"license"`from `"MIT"` to `"UNLICENSED"` in
- `package.json`
- `web/composer.json`