### PR TITLE
Use env command in hosting instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "shopify app dev",
     "push": "shopify app push",
     "scaffold": "shopify app scaffold",
-    "deploy": "shopify app deploy"
+    "deploy": "shopify app deploy",
+    "print-env": "shopify app env"
   },
   "dependencies": {
     "@shopify/app": "^3.0.0",

--- a/web/docs/hosting/fly-io.md
+++ b/web/docs/hosting/fly-io.md
@@ -56,7 +56,7 @@
         :
 
         [[services]]
-          internal_port = "8080"
+          internal_port = 8080
         :
         :
         ```
@@ -64,9 +64,9 @@
 1. Set the API secret and APP_KEY environment variables for your app:
 
     ```shell
-    cd .. && yarn print-env
+    (cd .. && yarn print-env)
     flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommand
-    cd web && php artisan key:generate --show
+    php artisan key:generate --show
     flyctl secrets set APP_KEY=ReplaceWithTheValueFromThePreviousCommand
     ```
 

--- a/web/docs/hosting/fly-io.md
+++ b/web/docs/hosting/fly-io.md
@@ -20,9 +20,9 @@
         Shopify app values:
         |Variable|Description/value|
         |-|-|
+        |`SHOPIFY_API_KEY`|Obtainable by running `yarn print-env`|
+        |`SCOPES`|Obtainable by running `yarn print-env`|
         |`PORT`|The port on which to run the app|
-        |`SHOPIFY_API_KEY`|API key for your app, from the Partners Dashboard|
-        |`SCOPES`|Comma-separated scopes for your app|
         |`HOST`|`fancy-cloud-1234.fly.dev`|
 
         Laravel values (note you can change the `DB_*` values if using a different database):
@@ -43,7 +43,7 @@
         :
         [env]
           PORT = "8080"
-          SHOPIFY_API_KEY="ReplaceWithAPIKeyFromPartnerDashboard"
+          SHOPIFY_API_KEY="ReplaceWithKEYFromEnvCommand"
           SCOPES="write_products"
           HOST="withered-dew-1234.fly.dev"
           APP_NAME="Test app"
@@ -56,7 +56,7 @@
         :
 
         [[services]]
-          internal_port = 8081
+          internal_port = "8080"
         :
         :
         ```
@@ -64,15 +64,16 @@
 1. Set the API secret and APP_KEY environment variables for your app:
 
     ```shell
-    flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromPartnerDashboard
-    php artisan key:generate --show
+    cd .. && yarn print-env
+    flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommand
+    cd web && php artisan key:generate --show
     flyctl secrets set APP_KEY=ReplaceWithTheValueFromThePreviousCommand
     ```
 
 1. Build and deploy the app - note that you'll need the `SHOPIFY_API_KEY` to pass to the command
 
     ```shell
-    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromPartnerDashboard
+    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommand
     ```
 
 ### Update URLs in Partner Dashboard

--- a/web/docs/hosting/heroku.md
+++ b/web/docs/hosting/heroku.md
@@ -30,7 +30,7 @@ git commit -m "Initial version"
         docker:
             web: web/Dockerfile
         config:
-            SHOPIFY_API_KEY: <Your API key from the Partners Dashboard>
+            SHOPIFY_API_KEY: <Your API key from `yarn print-env`>
     ```
 
 1. Set up the necessary environment variables to run in your app using the `heroku config:set` command. All the variables below should be set using a command like
@@ -42,9 +42,9 @@ git commit -m "Initial version"
     Shopify app values:
     |Variable|Description/value|
     |-|-|
-    |`SHOPIFY_API_KEY`|API key for your app, from the Partners Dashboard|
-    |`SHOPIFY_API_SECRET`|API secret key for your app, from the Partners Dashboard|
-    |`SCOPES`|Comma-separated scopes for your app|
+    |`SHOPIFY_API_KEY`|Obtainable by running `yarn print-env`|
+    |`SHOPIFY_API_SECRET`|Obtainable by running `yarn print-env`|
+    |`SCOPES`|Obtainable by running `yarn print-env`|
     |`HOST`|`my-app-name.herokuapp.com`|
 
     Laravel values (note you can change the `DB_*` values if using a different database):
@@ -52,7 +52,7 @@ git commit -m "Initial version"
     |-|-|
     |`APP_NAME`|App name for Laravel|
     |`APP_ENV`|`production`|
-    |`APP_KEY`|You can run `php web/artisan key:generate --show` to generate a new key|
+    |`APP_KEY`|Obtainable by running `php web/artisan key:generate --show`|
     |`DB_CONNECTION`|`sqlite`|
     |`DB_FOREIGN_KEYS`|`true`|
     |`DB_DATABASE`|`/app/storage/db.sqlite`|


### PR DESCRIPTION
We now have a command in the CLI that will print out the Shopify-specific values an app needs, so that developers don't need to go to the dashboard to set their apps up in a hosting platform.

This PR updates the hosting instructions to use that command instead of pointing folks to the dashboard (which is still a valid option but one more context switch).

Question: is the alias `deploy-env` good for this? We don't want to use `env` as that would overwrite the built-in `yarn env` command.