### PR TITLE
Disable composer timeout on serve process

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -46,7 +46,10 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
         ],
-        "serve": "php artisan serve --port=\"${BACKEND_PORT:-$PORT}\"",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "php artisan serve --port=\"${BACKEND_PORT:-$PORT}\""
+        ],
         "react": "npm run watch",
         "test": "php artisan test --env=testing",
         "lint": "./vendor/bin/phpcs --standard=PSR12 app tests routes",


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes when running the app, you'll get this error message:

> backend    | The following exception is caused by a process timeout
> backend    | Check https://getcomposer.org/doc/06-config.md#process-timeout for details
> backend    | 
> backend    |                                                                                                       
> backend    |   [Symfony\Component\Process\Exception\ProcessTimedOutException]                                      
> backend    |   The process "php artisan serve --port="${BACKEND_PORT:-$PORT}"" exceeded the timeout of 300 seconds.  
> backend    |                                                                                                       
> backend    | 
> backend    | serve [--dev] [--no-dev] [--] [<args>]...
> backend    | 

### WHAT is this pull request doing?

That happens because of the [default timeout composer sets for processes it runs](https://getcomposer.org/doc/06-config.md#process-timeout). Since the intent of the serve command is for it to run constantly, we can disable the timeout for that script.
