### PR TITLE
Rename env command to info

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "push": "shopify app push",
     "scaffold": "shopify app scaffold",
     "deploy": "shopify app deploy",
-    "print-env": "shopify app env"
+    "info": "shopify app info"
   },
   "dependencies": {
     "@shopify/app": "^3.0.0",

--- a/web/docs/hosting/fly-io.md
+++ b/web/docs/hosting/fly-io.md
@@ -20,8 +20,8 @@
         Shopify app values:
         |Variable|Description/value|
         |-|-|
-        |`SHOPIFY_API_KEY`|Obtainable by running `yarn print-env`|
-        |`SCOPES`|Obtainable by running `yarn print-env`|
+        |`SHOPIFY_API_KEY`|Obtainable by running `yarn run info --web-env`|
+        |`SCOPES`|Obtainable by running `yarn run info --web-env`|
         |`PORT`|The port on which to run the app|
         |`HOST`|`fancy-cloud-1234.fly.dev`|
 
@@ -64,7 +64,7 @@
 1. Set the API secret and APP_KEY environment variables for your app:
 
     ```shell
-    (cd .. && yarn print-env)
+    (cd .. && yarn run info --web-env)
     flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommand
     php artisan key:generate --show
     flyctl secrets set APP_KEY=ReplaceWithTheValueFromThePreviousCommand

--- a/web/docs/hosting/heroku.md
+++ b/web/docs/hosting/heroku.md
@@ -30,7 +30,7 @@ git commit -m "Initial version"
         docker:
             web: web/Dockerfile
         config:
-            SHOPIFY_API_KEY: <Your API key from `yarn print-env`>
+            SHOPIFY_API_KEY: <Your API key from `yarn run info --web-env`>
     ```
 
 1. Set up the necessary environment variables to run in your app using the `heroku config:set` command. All the variables below should be set using a command like
@@ -42,9 +42,9 @@ git commit -m "Initial version"
     Shopify app values:
     |Variable|Description/value|
     |-|-|
-    |`SHOPIFY_API_KEY`|Obtainable by running `yarn print-env`|
-    |`SHOPIFY_API_SECRET`|Obtainable by running `yarn print-env`|
-    |`SCOPES`|Obtainable by running `yarn print-env`|
+    |`SHOPIFY_API_KEY`|Obtainable by running `yarn run info --web-env`|
+    |`SHOPIFY_API_SECRET`|Obtainable by running `yarn run info --web-env`|
+    |`SCOPES`|Obtainable by running `yarn run info --web-env`|
     |`HOST`|`my-app-name.herokuapp.com`|
 
     Laravel values (note you can change the `DB_*` values if using a different database):


### PR DESCRIPTION
The `env` CLI command was replaced with `info --web-env`. This PR updates our instructions to use the new command once it's released.