### PR TITLE
Fix build command in web TOML file

### DIFF
--- a/web/shopify.web.toml
+++ b/web/shopify.web.toml
@@ -2,4 +2,4 @@ type="backend"
 
 [commands]
 dev = "composer serve"
-build = "composer build-frontend-links"
+build = "composer build"


### PR DESCRIPTION
This is just fixing up the `build` command for the backend in the web TOML file so that it is more generic (currently it is just an alias to the previous command).