### PR TITLE
Updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Shopify App Template - PHP
 
-This is a template for building a [Shopify embedded app](https://shopify.dev/apps/getting-started) using PHP and React. It contains the basics for building a Shopify app.
+This is a template for building a [Shopify app](https://shopify.dev/apps/getting-started) using PHP and React. It contains the basics for building a Shopify app.
+
+Rather than cloning this repo, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
 
 ## Benefits
 
@@ -28,7 +30,7 @@ This template combines a number of third party open source tools:
 These third party tools are complemented by Shopify specific tools to ease app development:
 
 -   [Shopify API library](https://github.com/Shopify/shopify-php-api) adds OAuth to the Laravel backend. This lets users install the app and grant scope permissions.
--   [App Bridge React](https://shopify.dev/tools/app-bridge/react-components) adds authentication to API requests in the frontend and renders components outside of the embedded App’s iFrame.
+-   [App Bridge React](https://shopify.dev/tools/app-bridge/react-components) adds authentication to API requests in the frontend and renders components outside of the App’s iFrame.
 -   [Polaris React](https://polaris.shopify.com/) is a powerful design system and component library that helps developers build high quality, consistent experiences for Shopify merchants.
 -   [Custom hooks](https://github.com/Shopify/shopify-frontend-template-react/tree/main/hooks) make authenticated requests to the GraphQL Admin API.
 -   [File-based routing](https://github.com/Shopify/shopify-frontend-template-react/blob/main/Routes.jsx) makes creating new pages easier.


### PR DESCRIPTION
### WHY are these changes introduced?

Removing the word 'embedded' because we are moving way from that term in our developer documentation. We don't have a specific term for this part of the app, but embedded isn't really helpful because extensions are also 'embedded' inside the admin or other Shopify surfaces.

For developer who view these repos, it may be helpful to hint to use a package manger earlier in the README.

### WHAT is this pull request doing?

This change removes mention of 'embedded' and provides a hint to use package managers and the CLI rather than cloning the repo.
