### PR TITLE
Move docker files up one level

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+web/vendor
+web/frontend/node_modules
+web/frontend/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update && apk add --update nodejs npm \
 
 RUN docker-php-ext-install pdo
 
-COPY --chown=www-data:www-data . /app
+COPY --chown=www-data:www-data web /app
 WORKDIR /app
 
 # Overwrite default nginx config

--- a/README.md
+++ b/README.md
@@ -8,30 +8,30 @@ Shopify apps are built on a variety of Shopify tools to create a great merchant 
 
 The PHP app template comes with the following out-of-the-box functionality:
 
--   OAuth: Installing the app and granting permissions
--   GraphQL Admin API: Querying or mutating Shopify admin data
--   REST Admin API: Resource classes to interact with the API
--   Shopify-specific tooling:
-    -   AppBridge
-    -   Polaris
-    -   Webhooks
+- OAuth: Installing the app and granting permissions
+- GraphQL Admin API: Querying or mutating Shopify admin data
+- REST Admin API: Resource classes to interact with the API
+- Shopify-specific tooling:
+  - AppBridge
+  - Polaris
+  - Webhooks
 
 ## Tech Stack
 
 This template combines a number of third party open source tools:
 
--   [Laravel](https://laravel.com/) builds and tests the backend.
--   [Vite](https://vitejs.dev/) builds the [React](https://reactjs.org/) frontend.
--   [React Router](https://reactrouter.com/) is used for routing. We wrap this with file-based routing.
--   [React Query](https://react-query.tanstack.com/) queries the GraphQL Admin API.
+- [Laravel](https://laravel.com/) builds and tests the backend.
+- [Vite](https://vitejs.dev/) builds the [React](https://reactjs.org/) frontend.
+- [React Router](https://reactrouter.com/) is used for routing. We wrap this with file-based routing.
+- [React Query](https://react-query.tanstack.com/) queries the GraphQL Admin API.
 
 These third party tools are complemented by Shopify specific tools to ease app development:
 
--   [Shopify API library](https://github.com/Shopify/shopify-php-api) adds OAuth to the Laravel backend. This lets users install the app and grant scope permissions.
--   [App Bridge React](https://shopify.dev/tools/app-bridge/react-components) adds authentication to API requests in the frontend and renders components outside of the embedded App’s iFrame.
--   [Polaris React](https://polaris.shopify.com/) is a powerful design system and component library that helps developers build high quality, consistent experiences for Shopify merchants.
--   [Custom hooks](https://github.com/Shopify/shopify-frontend-template-react/tree/main/hooks) make authenticated requests to the GraphQL Admin API.
--   [File-based routing](https://github.com/Shopify/shopify-frontend-template-react/blob/main/Routes.jsx) makes creating new pages easier.
+- [Shopify API library](https://github.com/Shopify/shopify-php-api) adds OAuth to the Laravel backend. This lets users install the app and grant scope permissions.
+- [App Bridge React](https://shopify.dev/tools/app-bridge/react-components) adds authentication to API requests in the frontend and renders components outside of the embedded App’s iFrame.
+- [Polaris React](https://polaris.shopify.com/) is a powerful design system and component library that helps developers build high quality, consistent experiences for Shopify merchants.
+- [Custom hooks](https://github.com/Shopify/shopify-frontend-template-react/tree/main/hooks) make authenticated requests to the GraphQL Admin API.
+- [File-based routing](https://github.com/Shopify/shopify-frontend-template-react/blob/main/Routes.jsx) makes creating new pages easier.
 
 ## Getting started
 
@@ -74,27 +74,39 @@ However, the CLI will not manage your PHP dependencies automatically, so you wil
 These are the typical steps needed to set up a Laravel app once it's cloned:
 
 1. Start off by switching to the `web` folder:
+
     ```shell
     cd web
     ```
+
 1. Install your composer dependencies:
+
     ```shell
     composer install
     ```
+
 1. Create the `.env` file:
+
     ```shell
     cp .env.example .env
     ```
+
 1. Bootstrap the default [SQLite](https://www.sqlite.org/index.html) database and add it to your `.env` file:
+
     ```shell
     touch storage/db.sqlite
     ```
+
     **NOTE**: Once you create the database file, make sure to update your `DB_DATABASE` variable in `.env` since Laravel requires a full path to the file.
+
 1. Generate an `APP_KEY` for your app:
+
     ```shell
     php artisan key:generate
     ```
+
 1. Create the necessary Shopify tables in your database:
+
     ```shell
     php artisan migrate
     ```
@@ -214,12 +226,12 @@ You'll need to set up the API key and API secret for your production environment
 
 The following pages document the basic steps to host and deploy your application to a few popular cloud providers:
 
--   [fly.io](/web/docs/hosting/fly-io.md)
--   [Heroku](/web/docs/hosting/heroku.md)
+- [fly.io](/web/docs/hosting/fly-io.md)
+- [Heroku](/web/docs/hosting/heroku.md)
 
 ## Developer resources
 
--   [Introduction to Shopify apps](https://shopify.dev/apps/getting-started)
--   [App authentication](https://shopify.dev/apps/auth)
--   [Shopify CLI](https://shopify.dev/apps/tools/cli)
--   [Shopify API Library documentation](https://github.com/Shopify/shopify-php-api/tree/main/docs)
+- [Introduction to Shopify apps](https://shopify.dev/apps/getting-started)
+- [App authentication](https://shopify.dev/apps/auth)
+- [Shopify CLI](https://shopify.dev/apps/tools/cli)
+- [Shopify API Library documentation](https://github.com/Shopify/shopify-php-api/tree/main/docs)

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,3 +1,0 @@
-vendor
-frontend/node_modules
-frontend/dist

--- a/web/docs/hosting/fly-io.md
+++ b/web/docs/hosting/fly-io.md
@@ -11,8 +11,29 @@
 
 ### Build and deploy a container
 
-1. Change in to the `web` directory: `cd web`.
 1. Create an app using `flyctl launch`. You can choose your own app name or press enter to let Fly pick an app name. Choose a region for deployment (it should default to the closest one to you). Choose _No_ for DB to use the default SQLite database, or select a different one otherwise. Choose _No_ to deploy now.
+1. To create a new app in the Partner Dashboard or to link the app to an existing app, run the following command using your preferred package manager:
+
+      Using yarn:
+
+      ```shell
+      yarn run info --web-env
+      ```
+
+      Using npm:
+
+      ```shell
+      npm run info --web-env
+      ```
+
+      Using pnpm:
+
+      ```shell
+      pnpm run info --web-env
+      ```
+
+      Take note of the `SCOPES`, `SHOPIFY_API_KEY` and the `SHOPIFY_API_SECRET` values, as you'll need them in the next steps.
+
 1. Make the following changes to the `fly.toml` file.
 
     - In the `[env]` section, add the following environment variables (in a `"` delimited string):
@@ -20,10 +41,10 @@
         Shopify app values:
         |Variable|Description/value|
         |-|-|
-        |`SHOPIFY_API_KEY`|Obtainable by running `yarn run info --web-env`|
-        |`SCOPES`|Obtainable by running `yarn run info --web-env`|
+        |`SHOPIFY_API_KEY`|Can be obtained from the `run info --web-env` command in the previous step|
+        |`SCOPES`|Can be obtained from the `run info --web-env` command in the previous step|
         |`PORT`|The port on which to run the app|
-        |`HOST`|`fancy-cloud-1234.fly.dev`|
+        |`HOST`|Set this to the URL of the new app, which can be constructed by taking the `app` variable at the very top of the `fly.toml` file, prepending it with `https://` and adding `.fly.dev` to the end, e.g, if `app` is `"fancy-cloud-1234"`, then `HOST` should be set to `https://fancy-cloud-1234.fly.dev`|
 
         Laravel values (note you can change the `DB_*` values if using a different database):
         |Variable|Description/value|
@@ -64,7 +85,6 @@
 1. Set the API secret and APP_KEY environment variables for your app:
 
     ```shell
-    (cd .. && yarn run info --web-env)
     flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommand
     php artisan key:generate --show
     flyctl secrets set APP_KEY=ReplaceWithTheValueFromThePreviousCommand
@@ -73,7 +93,7 @@
 1. Build and deploy the app - note that you'll need the `SHOPIFY_API_KEY` to pass to the command
 
     ```shell
-    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommand
+    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommand --remote-only
     ```
 
 ### Update URLs in Partner Dashboard
@@ -85,10 +105,10 @@ In the Partner Dashboard, update the main URL for your app to the url from the [
 After updating your code with new features and fixes, rebuild and redeploy using:
 
 ```shell
-flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKeyFromPartnerDashboard
+flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommand --remote-only
 ```
 
 ## To scale to multiple regions
 
 1. Add a new region using `flyctl regions add CODE`, where `CODE` is the three-letter code for the region. To obtain a list of regions and code, run `flyctl platform regions`.
-2. Scale to two instances - `flyctl scale count 2`
+1. Scale to two instances - `flyctl scale count 2`

--- a/web/docs/hosting/heroku.md
+++ b/web/docs/hosting/heroku.md
@@ -17,21 +17,33 @@ git commit -m "Initial version"
 
 ## Build and deploy from Git repo
 
-1. Create an app in Heroku using `heroku create -a my-app-name`. This will create a git remote named `heroku` for deploying the app to Heroku. It will also return the URL to where the app will run when deployed, in the form of:
+1. Create an app in Heroku using `heroku create -a my-app-name -s container`. This will create a git remote named `heroku` for deploying the app to Heroku. It will also return the URL to where the app will run when deployed, in the form of:
 
     ```text
     https://my-app-name.herokuapp.com
     ```
 
-1. In your app's root directory, create a `heroku.yml` file that contains instructions for building your Heroku app:
+1. To create a new app in the Partner Dashboard or to link the app to an existing app, run the following command using your preferred package manager:
+
+    Using yarn:
 
     ```shell
-    build:
-        docker:
-            web: web/Dockerfile
-        config:
-            SHOPIFY_API_KEY: <Your API key from `yarn run info --web-env`>
+    yarn run info --web-env
     ```
+
+    Using npm:
+
+    ```shell
+    npm run info --web-env
+    ```
+
+    Using pnpm:
+
+    ```shell
+    pnpm run info --web-env
+    ```
+
+    Take note of the `SCOPES`, `SHOPIFY_API_KEY` and the `SHOPIFY_API_SECRET` values, as you'll need them in the next steps.
 
 1. Set up the necessary environment variables to run in your app using the `heroku config:set` command. All the variables below should be set using a command like
 
@@ -42,9 +54,9 @@ git commit -m "Initial version"
     Shopify app values:
     |Variable|Description/value|
     |-|-|
-    |`SHOPIFY_API_KEY`|Obtainable by running `yarn run info --web-env`|
-    |`SHOPIFY_API_SECRET`|Obtainable by running `yarn run info --web-env`|
-    |`SCOPES`|Obtainable by running `yarn run info --web-env`|
+    |`SHOPIFY_API_KEY`|can be obtained from the `run info --web-env` command in the previous step|
+    |`SHOPIFY_API_SECRET`|can be obtained from the `run info --web-env` command in the previous step|
+    |`SCOPES`|can be obtained from the `run info --web-env` command in the previous step|
     |`HOST`|`my-app-name.herokuapp.com`|
 
     Laravel values (note you can change the `DB_*` values if using a different database):
@@ -57,17 +69,21 @@ git commit -m "Initial version"
     |`DB_FOREIGN_KEYS`|`true`|
     |`DB_DATABASE`|`/app/storage/db.sqlite`|
 
+1. In your app's root directory, create a `heroku.yml` file that contains instructions for building your Heroku app:
+
+    ```yaml
+    build:
+      docker:
+        web: web/Dockerfile
+      config:
+        SHOPIFY_API_KEY: ReplaceWithKEYFromEnvCommand
+    ```
+
 1. Add the Heroku config file to your git repo:
 
     ```shell
     git add heroku.yml
-    git commit -m "Adding Heroku config file"
-    ```
-
-1. Set the stack of your app to `container`:
-
-    ```shell
-    heroku stack:set container
+    git commit -m "Add Heroku config file"
     ```
 
 1. Push the app to Heroku. This will automatically deploy the app.


### PR DESCRIPTION
### WHY are these changes introduced?

To remove friction in the user guide - changing directories for hosting deployments and CLI use

### WHAT is this pull request doing?

- Moves the `Dockerfile` and `.dockerignore` files up a level
- Changes the instructions accordingly