### PR TITLE
Change how we check if the app is Embedded

### DIFF
--- a/web/resources/views/top_level.blade.php
+++ b/web/resources/views/top_level.blade.php
@@ -3,12 +3,13 @@
 
 <head>
     <title>Shopify PHP App</title>
-    <script src="https://unpkg.com/@shopify/app-bridge@2"></script>
+    <script src="https://unpkg.com/@shopify/app-bridge@3.1.0"></script>
+    <script src="https://unpkg.com/@shopify/app-bridge-utils@3.1.0"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            if (window.top === window.self) {
-                window.location.href = '/api/auth?shop={{$shop}}';
-            } else {
+            var appBridgeUtils = window['app-bridge-utils'];
+
+            if (appBridgeUtils.isShopifyEmbedded()) {
                 var AppBridge = window['app-bridge'];
                 var createApp = AppBridge.default;
                 var Redirect = AppBridge.actions.Redirect;
@@ -21,6 +22,8 @@
                 const redirect = Redirect.create(app);
 
                 redirect.dispatch(Redirect.Action.REMOTE, 'https://{{$hostName}}/api/auth/toplevel?shop={{$shop}}');
+            } else {
+                window.location.href = '/api/auth?shop={{$shop}}';
             }
         });
     </script>


### PR DESCRIPTION
### WHY are these changes introduced?
We want to support unframed.   To do this we need to change how we check how to redirect.

### WHAT is this pull request doing?
Using `. isShopifyEmbedded()` instead of `window.top === window.self`

### Tophatting
- In shopify-cli-next run `yarn create-app --template=https://github.com/Shopify/shopify-app-template-php#support-unframed`
- cd into the newly created directory
- run `yarn dev`
- Open the URL in the browser, the app should render inside the admin.
