### PR TITLE
Update dependabot for new template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,36 @@
 version: 2
 updates:
+  # Enable version updates for composer - cli_three/web (new template)
   - package-ecosystem: composer
-    directory: "/"
+    directory: "/web"
     schedule:
       interval: "daily"
       time: "00:00"
       timezone: "UTC"
+    # Raise PRs for composer updates against the `cli_three` branch
+    target-branch: "cli_three"
     reviewers:
       - Shopify/client-libraries-atc
     labels:
+      - "cli_three"
       - "Composer upgrades"
     open-pull-requests-limit: 100
+
+  # Enable version updates for npm - cli_three/ (new template)
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    # This will be CLI dependencies only
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+      time: "00:00"
+      timezone: "UTC"
+    # Raise PRs for version updates to npm against the `cli_three` branch
+    target-branch: "cli_three"
+    reviewers:
+      - Shopify/client-libraries-atc
+    # Labels on pull requests for version updates only
+    labels:
+      - "cli_three"
+      - "npm dependencies"


### PR DESCRIPTION
### WHY are these changes introduced?

Dependabot is configured for `main` only - need to add it for `cli_three` branch also.

### WHAT is this pull request doing?

Update `dependabot.yml` file with the necessary config