### PR TITLE
Fix npm init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ yarn create @shopify/app --template php
 Using npx:
 
 ```shell
-npm init @shopify/app --template php
+npm init @shopify/app@latest --template php
 ```
 
 Using pnpm:


### PR DESCRIPTION
### WHY are these changes introduced?

`npm init` caches heavily, hence need to force it to get the latest version

### WHAT is this pull request doing?

Change the `npm init @shopify/app --template php` to `npm init @shopify/app@latest --template php`