### PR TITLE
Ignore incomplete sessions when checking if app is installed

### DIFF
--- a/web/tests/Feature/RootTest.php
+++ b/web/tests/Feature/RootTest.php
@@ -19,6 +19,22 @@ class RootTest extends BaseTestCase
         $response->assertRedirect("/api/auth?shop=test-shop.myshopify.io");
     }
 
+    public function testReturn302IfShopHasIncompleteOAuthProcess()
+    {
+        $session = new Session(
+            "test-session-id",
+            "test-shop.myshopify.io",
+            false,
+            "test-session-state"
+        );
+
+        Context::$SESSION_STORAGE->storeSession($session);
+
+        $response = $this->get("?shop=test-shop.myshopify.io");
+        $response->assertStatus(302);
+        $response->assertRedirect("/api/auth?shop=test-shop.myshopify.io");
+    }
+
     public function testReturn200IfShopIsAlreadyInstalled()
     {
         $session = new Session(
@@ -27,6 +43,7 @@ class RootTest extends BaseTestCase
             false,
             "test-session-state"
         );
+        $session->setAccessToken("dummy-token");
 
         Context::$SESSION_STORAGE->storeSession($session);
 
@@ -43,6 +60,7 @@ class RootTest extends BaseTestCase
             false,
             "test-session-state"
         );
+        $session->setAccessToken("dummy-token");
 
         Context::$SESSION_STORAGE->storeSession($session);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #235 
Fixes #236 

When the app checked if it was already installed to a shop before checking if it needed to start an OAuth flow, it was looking for _any_ session for that shop, not necessarily one that was completed.

If a shop started the process but never actually installed the app, it would find that incomplete session in the database and think it was a valid install, and not attempt to re-authenticate.

### WHAT is this pull request doing?

Fixing that by ensuring that only _completed_ sessions count when checking if the app is installed

## Checklist

- [x] I have added/updated tests for this change
