### PR TITLE
Use v3 of API lib

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\URL;
 use Shopify\Context;
+use Shopify\ApiVersion;
 use Shopify\Webhooks\Registry;
 use Shopify\Webhooks\Topics;
 
@@ -36,7 +37,8 @@ class AppServiceProvider extends ServiceProvider
             Config::get('shopify.api_secret'),
             Config::get('shopify.scopes'),
             str_replace('https://', '', Config::get('shopify.host')),
-            new DbSessionStorage()
+            new DbSessionStorage(),
+            ApiVersion::LATEST
         );
 
         URL::forceScheme('https');

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.12",
         "laravel/tinker": "^2.5",
-        "shopify/shopify-api": "^2.0",
+        "shopify/shopify-api": "^3.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c86ee1697fea0f6db3f902cca3bb5b65",
+    "content-hash": "134743df487196a0d0e82bf0a065f16b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3297,16 +3297,16 @@
         },
         {
             "name": "shopify/shopify-api",
-            "version": "v2.0.1",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Shopify/shopify-php-api.git",
-                "reference": "0556edf274ceb83346533bd22b662d7622e58c66"
+                "url": "https://github.com/Shopify/shopify-api-php.git",
+                "reference": "78a0416b1b6a50a11c1a942e7bdc456bcd8951c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Shopify/shopify-php-api/zipball/0556edf274ceb83346533bd22b662d7622e58c66",
-                "reference": "0556edf274ceb83346533bd22b662d7622e58c66",
+                "url": "https://api.github.com/repos/Shopify/shopify-api-php/zipball/78a0416b1b6a50a11c1a942e7bdc456bcd8951c9",
+                "reference": "78a0416b1b6a50a11c1a942e7bdc456bcd8951c9",
                 "shasum": ""
             },
             "require": {
@@ -3352,10 +3352,10 @@
                 "webhook"
             ],
             "support": {
-                "issues": "https://github.com/Shopify/shopify-php-api/issues",
-                "source": "https://github.com/Shopify/shopify-php-api/tree/v2.0.1"
+                "issues": "https://github.com/Shopify/shopify-api-php/issues",
+                "source": "https://github.com/Shopify/shopify-api-php/tree/v3.0.0"
             },
-            "time": "2022-04-11T17:51:03+00:00"
+            "time": "2022-07-04T16:09:41+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -8472,5 +8472,5 @@
         "php": "^7.4 || ^8.0 || ^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/tests/Feature/CallbackTest.php
+++ b/tests/Feature/CallbackTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Shopify\Auth\OAuth;
 use Shopify\Auth\Session;
 use Shopify\Context;
+use Shopify\ApiVersion;
 
 class CallbackTest extends BaseTestCase
 {
@@ -60,7 +61,7 @@ class CallbackTest extends BaseTestCase
         Context::$SESSION_STORAGE->storeSession($offlineSession);
 
         $oauthTokenUrl = "https://test-shop.myshopify.io/admin/oauth/access_token";
-        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/unstable/graphql.json";
+        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/" . ApiVersion::LATEST . "/graphql.json";
 
         $client = $this->mockClient();
         $client->expects($this->exactly(3))
@@ -125,7 +126,7 @@ class CallbackTest extends BaseTestCase
         Context::$SESSION_STORAGE->storeSession($onlineSession);
 
         $oauthTokenUrl = "https://test-shop.myshopify.io/admin/oauth/access_token";
-        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/unstable/graphql.json";
+        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/" . ApiVersion::LATEST . "/graphql.json";
 
         $client = $this->mockClient();
         $client->expects($this->exactly(3))

--- a/tests/Feature/ProxyGraphqlTest.php
+++ b/tests/Feature/ProxyGraphqlTest.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Shopify\Auth\OAuth;
 use Shopify\Auth\Session;
 use Shopify\Context;
+use Shopify\ApiVersion;
 
 class ProxyGraphqlTest extends BaseTestCase
 {
@@ -47,7 +48,7 @@ class ProxyGraphqlTest extends BaseTestCase
         $this->assertTrue(Context::$SESSION_STORAGE->storeSession($session));
         $this->assertEquals($session, Context::$SESSION_STORAGE->loadSession($sessionId));
 
-        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/unstable/graphql.json";
+        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/" . ApiVersion::LATEST . "/graphql.json";
 
         $client = $this->mockClient();
         $client->expects($this->exactly(2))

--- a/tests/Feature/RestExampleTest.php
+++ b/tests/Feature/RestExampleTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Shopify\Auth\OAuth;
 use Shopify\Auth\Session;
 use Shopify\Context;
+use Shopify\ApiVersion;
 
 class RestExampleTest extends BaseTestCase
 {
@@ -35,8 +36,8 @@ class RestExampleTest extends BaseTestCase
 
         $this->assertTrue(Context::$SESSION_STORAGE->storeSession($session));
 
-        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/unstable/graphql.json";
-        $restUrl = "https://test-shop.myshopify.io/admin/api/unstable/products.json?limit=5";
+        $graphqlUrl = "https://test-shop.myshopify.io/admin/api/" . ApiVersion::LATEST . "/graphql.json";
+        $restUrl = "https://test-shop.myshopify.io/admin/api/" . ApiVersion::LATEST . "/products.json?limit=5";
         $restResponse = [
             'data' => [
                 'products' => [


### PR DESCRIPTION
### WHY are these changes introduced?

Upgrading the template to use v3 of the PHP library.

### WHAT is this pull request doing?

- Updates the `composer.json` configuration to use v3
- Can also use `ApiVersion::LATEST` in `Context::initialize()` which will make future updating easier.
- Update tests accordingly to use `ApiVersion::LATEST`