### PR TITLE
Remove port argument from serve command

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -6,6 +6,8 @@
     "license": "UNLICENSED",
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1",
+        "ext-xml": "*",
+        "ext-zip": "*",
         "doctrine/dbal": "^3.1",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
@@ -48,7 +50,7 @@
         ],
         "serve": [
             "Composer\\Config::disableProcessTimeout",
-            "php artisan serve --port=\"${BACKEND_PORT:-$PORT}\""
+            "php artisan serve"
         ],
         "react": "npm run watch",
         "test": "php artisan test --env=testing",

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c86ee1697fea0f6db3f902cca3bb5b65",
+    "content-hash": "1ae949798eff5a2840fbb1093f53a997",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8469,7 +8469,9 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ^8.0 || ^8.1"
+        "php": "^7.4 || ^8.0 || ^8.1",
+        "ext-xml": "*",
+        "ext-zip": "^1.19"
     },
     "platform-dev": [],
     "plugin-api-version": "2.2.0"


### PR DESCRIPTION
### WHY are these changes introduced?

When running the app on Windows, the PORT env var with a fallback was not proper batch syntax, and thus broke the `serve` command.

### WHAT is this pull request doing?

Since the CLI sets `SERVER_PORT` now, we don't need that argument at all any more, so we can just run the server without any port overrides, which should work for all OSs.

I also took the chance to add a couple of missing extension requirements to the composer.json file.