### PR TITLE
Add CSP headers to set frame-ancestors

### DIFF
--- a/web/app/Http/Kernel.php
+++ b/web/app/Http/Kernel.php
@@ -37,6 +37,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\CspHeader::class,
         ],
 
         'api' => [

--- a/web/app/Http/Middleware/CspHeader.php
+++ b/web/app/Http/Middleware/CspHeader.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Shopify\Context;
+use Shopify\Utils;
+
+class CspHeader
+{
+    /**
+     * Ensures that the request is setting the appropriate CSP frame-ancestor directive.
+     *
+     * See https://shopify.dev/apps/store/security/iframe-protection for more information
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $shop = Utils::sanitizeShopDomain($request->query('shop', ''));
+
+        if (Context::$IS_EMBEDDED_APP) {
+            $domainHost = $shop ? "https://$shop" : "*.myshopify.com";
+            $allowedDomains = "$domainHost https://admin.shopify.com";
+        } else {
+            $allowedDomains = "'none'";
+        }
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        $currentHeader = $response->headers->get('Content-Security-Policy');
+        if ($currentHeader) {
+            $values = preg_split("/;\s*/", $currentHeader);
+
+            // Replace or add the URLs the frame-ancestors directive
+            $found = false;
+            foreach ($values as $index => $value) {
+                if (mb_strpos($value, "frame-ancestors") === 0) {
+                    $values[$index] = preg_replace("/^(frame-ancestors)/", "$1 $allowedDomains", $value);
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (!$found) {
+                $values[] = "frame-ancestors $allowedDomains";
+            }
+
+            $headerValue = implode("; ", $values);
+        } else {
+            $headerValue = "frame-ancestors $allowedDomains;";
+        }
+
+
+        $response->headers->set('Content-Security-Policy', $headerValue);
+
+        return $response;
+    }
+}

--- a/web/tests/BaseTestCase.php
+++ b/web/tests/BaseTestCase.php
@@ -18,6 +18,7 @@ class BaseTestCase extends TestCase
         $factory->expects($this->any())
             ->method('client');
         Context::$HTTP_CLIENT_FACTORY = $factory;
+        Context::$IS_EMBEDDED_APP = true;
     }
 
     /**

--- a/web/tests/Feature/RootTest.php
+++ b/web/tests/Feature/RootTest.php
@@ -35,8 +35,13 @@ class RootTest extends BaseTestCase
         $response->assertRedirect("/api/auth?shop=test-shop.myshopify.io");
     }
 
-    public function testReturn200IfShopIsAlreadyInstalled()
+    /**
+     * @dataProvider provideFrameAncestors
+     */
+    public function testReturn200IfShopIsAlreadyInstalled($isEmbedded, $frameAncestors)
     {
+        Context::$IS_EMBEDDED_APP = $isEmbedded;
+
         $session = new Session(
             "test-session-id",
             "test-shop.myshopify.io",
@@ -50,6 +55,15 @@ class RootTest extends BaseTestCase
         $response = $this->get("?shop=test-shop.myshopify.io");
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'text/html; charset=UTF-8');
+        $response->assertHeader('Content-Security-Policy', "frame-ancestors $frameAncestors;");
+    }
+
+    public function provideFrameAncestors()
+    {
+        return [
+            [true, "https://test-shop.myshopify.io https://admin.shopify.com"],
+            [false, "'none'"],
+        ];
     }
 
     public function testUncaughtRequestsTriggerRouteBehaviour()


### PR DESCRIPTION
### WHY are these changes introduced?

As per [the docs](https://shopify.dev/apps/store/security/iframe-protection), we should be setting the CSP headers for embedded apps, so they can only be loaded within the admin.

### WHAT is this pull request doing?

Adding a middleware that sets the appropriate ancestors based on the `shop` and whether the app is embedded or not.

## Checklist

- [x] I have added/updated tests for this change
