### PR TITLE
Check if latest session is valid on page loads

### DIFF
--- a/web/app/Lib/AuthRedirection.php
+++ b/web/app/Lib/AuthRedirection.php
@@ -16,7 +16,7 @@ class AuthRedirection
     {
         $shop = Utils::sanitizeShopDomain($request->query("shop"));
 
-        if ($request->query("embedded", false) === "1") {
+        if (Context::$IS_EMBEDDED_APP && $request->query("embedded", false) === "1") {
             $redirectUrl = self::clientSideRedirectUrl($shop, $request->query());
         } else {
             $redirectUrl = self::serverSideRedirectUrl($shop, $isOnline);

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -13,6 +13,7 @@ use Shopify\Auth\OAuth;
 use Shopify\Auth\Session as AuthSession;
 use Shopify\Clients\HttpHeaders;
 use Shopify\Clients\Rest;
+use Shopify\Context;
 use Shopify\Exception\InvalidWebhookException;
 use Shopify\Utils;
 use Shopify\Webhooks\Registry;
@@ -29,11 +30,15 @@ use Shopify\Webhooks\Topics;
 |
 */
 
-Route::fallback(function () {
-    if (env('APP_ENV') === 'production') {
-        return file_get_contents(public_path('index.html'));
+Route::fallback(function (Request $request) {
+    if (Context::$IS_EMBEDDED_APP &&  $request->query("embedded", false) === "1") {
+        if (env('APP_ENV') === 'production') {
+            return file_get_contents(public_path('index.html'));
+        } else {
+            return file_get_contents(base_path('frontend/index.html'));
+        }
     } else {
-        return file_get_contents(base_path('frontend/index.html'));
+        return redirect(Utils::getEmbeddedAppUrl($request->query("host", null)));
     }
 })->middleware('shopify.installed');
 


### PR DESCRIPTION
### WHY are these changes introduced?

When a session expires / the app scopes change, we'll need to refresh the session for shops before we can request data. Currently, we're relying on our `EnsureShopifySession` middleware to do that check, which means that the app will still load, but fail the first time it tries to fetch data.

### WHAT is this pull request doing?

Enhancing the `EnsureShopifyInstalled` middleware to fetch the latest session for the shop and check if it's actually valid, rather than just checking for its existence.