### PR TITLE
Fix infinite loop in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 /web/vendor
 /web/composer.lock
 .env
+.env.*
+!.env.example
+!.env.testing
 web/.phpunit.result.cache
 docker-compose.override.yml
 Homestead.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG SHOPIFY_API_KEY
 ENV SHOPIFY_API_KEY=$SHOPIFY_API_KEY
 
 RUN apk update && apk add --update nodejs npm \
-  composer php-pdo_sqlite php-pdo_mysql php-pdo_pgsql php-simplexml php-fileinfo php-dom php-tokenizer php-xml php-xmlwriter php-session \
-  openrc bash nginx
+    composer php-pdo_sqlite php-pdo_mysql php-pdo_pgsql php-simplexml php-fileinfo php-dom php-tokenizer php-xml php-xmlwriter php-session \
+    openrc bash nginx
 
 RUN docker-php-ext-install pdo
 
@@ -19,7 +19,7 @@ COPY web/nginx.conf /etc/nginx/nginx.conf
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 RUN composer install
-RUN echo "" > /app/storage/db.sqlite
+RUN touch /app/storage/db.sqlite
 RUN chown www-data:www-data /app/storage/db.sqlite
 
 RUN cd frontend && npm install && npm run build

--- a/web/app/Http/Middleware/EnsureShopifyInstalled.php
+++ b/web/app/Http/Middleware/EnsureShopifyInstalled.php
@@ -20,8 +20,10 @@ class EnsureShopifyInstalled
     public function handle(Request $request, Closure $next)
     {
         $shop = $request->query('shop') ? Utils::sanitizeShopDomain($request->query('shop')) : null;
-        $appInstalled = $shop && Session::where('shop', $shop)->where('access_token', '<>', null)->exists();
 
-        return $appInstalled ? $next($request) : AuthRedirection::redirect($request);
+        $appInstalled = $shop && Session::where('shop', $shop)->where('access_token', '<>', null)->exists();
+        $isExitingIframe = preg_match("/^ExitIframe/i", $request->path());
+
+        return ($appInstalled || $isExitingIframe) ? $next($request) : AuthRedirection::redirect($request);
     }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

There was a scenario in production where we could end up on a redirect loop if the production DB got wiped, but Shopify still thinks the app is installed (unlikely but you never know).

We would redirect to `/exitiframe` upon learning that we needed to break out of the iframe, which in production gets rendered by the `/*` route, which would trigger another redirect.

### WHAT is this pull request doing?

Letting requests to `/exitiframe` go through to the client-side where it'll get properly rendered by the React app.