### PR TITLE
Correcting Instructions for Installing using the PHP template

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,31 @@ This template runs on Shopify CLI 3.0, which is a node package that can be inclu
 Using yarn:
 
 ```shell
-yarn create @shopify/app --template php
+yarn create @shopify/app
 ```
 
 Using npx:
 
 ```shell
-npm init @shopify/app@latest --template php
+npm init @shopify/app@latest
 ```
 
 Using pnpm:
 
 ```shell
-pnpm create @shopify/app@latest --template php
+pnpm create @shopify/app@latest
 ```
 
-This will clone the template and install the CLI in that project.
+The installer will then prompt you for:
+1. Your App's name? (this will become the directory name: for example my-app)
+1. Which template would you like to use? (use the arrow keys to select PHP)
 
+This will clone the template and install the CLI in a directory relative to the directory that you were in when you ran the installer. The installer also prints instructions for what to do next.
+
+```shell
+cd my-app
+```
+    
 ### Setting up your Laravel app
 
 Once the Shopify CLI clones the repo, you will be able to run commands on your app.


### PR DESCRIPTION
the current Shopify installer prompts the user for the templates to use and directory name: adding the template as an argument (as currently shown) creates an error.


### WHY are these changes introduced?

The current instructions generate an error:
```shell
npm init @shopify/app@latest --template php
```
results in:
```shell
━━━━━━ Error ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    Unexpected argument: php
```

### WHAT is this pull request doing?

These changes remove the argument from the command in the instructions: the current installer uses prompts:

```shell
npm init @shopify/app@latest 
```
```shell
Welcome. Let’s get started by naming your app. You can change it later.
? Your app's name? 
> test1
  ──────────────────────────────
? Which template would you like to use? … 
  node 
> php 
  ruby 
```

## Checklist

I have tested this on all three installation methods on MacOSx.
