### PR TITLE
Fix issue when setting cookies in HTTP mode

### DIFF
--- a/web/app/Lib/CookieHandler.php
+++ b/web/app/Lib/CookieHandler.php
@@ -17,7 +17,7 @@ class CookieHandler
             $cookie->getValue(),
             $cookie->getExpire() ? ceil(($cookie->getExpire() - time()) / 60) : null,
             '/',
-            Context::$HOST_NAME,
+            parse_url(Context::$HOST_SCHEME . "://" . Context::$HOST_NAME, PHP_URL_HOST),
             $cookie->isSecure(),
             $cookie->isHttpOnly(),
             false,


### PR DESCRIPTION
### WHY are these changes introduced?

When setting cookies in HTTP mode, we were using `Context::$HOST_NAME`, which might include a port if running on an address such as `localhost:9999`. Laravel won't ignore the port in the domain, so we need to filter it out before setting it.

### WHAT is this pull request doing?

Ensuring we set a valid domain for both HTTPS and HTTP modes.