### PR TITLE
Update API library version

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.12",
         "laravel/tinker": "^2.5",
-        "shopify/shopify-api": "^3.1",
+        "shopify/shopify-api": "^4.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "require-dev": {


### PR DESCRIPTION
This PR simply updates the API library to the latest version, which drops support for the now deprecated `2021-10` API version and adds `2022-10`.