### PR TITLE
[Fix] Delete rule to ignore Yarn lock.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
-yarn.lock
 
 **/node_modules
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The composer.lock file was added, which makes sense, so the yarn.lock might be relevant to keep on track of the used packages' versions to apps coming from this template.

### WHAT is this pull request doing?

It's allowing by default the versioning of the yarn.lock file, as the composer.lock was added.

## Checklist

- [ ] I have added/updated tests for this change
