### PR TITLE
Add `not_planned` reason to Stale Workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,3 +30,4 @@ jobs:
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           exempt-issue-labels: "feature request"
+          close-issue-reason: "not_planned"


### PR DESCRIPTION
## Description

Issues that were closed by our stale workflow were getting closed as "complete". This might be confusing so we should close as `not_planned`.

[We are also doing this in `shopify_app`](https://github.com/Shopify/shopify_app/pull/1582)
## Checklist

- [ ] I have added/updated tests for this change
