### PR TITLE
Update README to add Plus Sandbox as a valid store

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These third party tools are complemented by Shopify specific tools to ease app d
 ### Requirements
 
 1. You must [create a Shopify partner account](https://partners.shopify.com/signup) if you don’t have one.
-1. You must [create a development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) if you don’t have one.
+1. You must [create a development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or [Shopify Plus sandbox](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store) store if you don’t have one.
 1. You must have [PHP](https://www.php.net/) installed.
 1. You must have [Composer](https://getcomposer.org/) installed.
 1. You must have [Node.js](https://nodejs.org/) installed.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These third party tools are complemented by Shopify specific tools to ease app d
 ### Requirements
 
 1. You must [create a Shopify partner account](https://partners.shopify.com/signup) if you don’t have one.
-1. You must [create a development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or [Shopify Plus sandbox](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store) store if you don’t have one.
+1. You must create a store for testing if you don't have one, either a [development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or a [Shopify Plus sandbox store](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store).
 1. You must have [PHP](https://www.php.net/) installed.
 1. You must have [Composer](https://getcomposer.org/) installed.
 1. You must have [Node.js](https://nodejs.org/) installed.


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/pull/1254

### WHAT is this pull request doing?

Update the readme to include Shopify Plus Sandbox stores in the requirements

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [x] I have made changes to the `README.md` file and other related documentation, if applicable
