### PR TITLE
Update shopify.dev links to include /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Shopify App Template - PHP
 
-This is a template for building a [Shopify app](https://shopify.dev/apps/getting-started) using PHP and React. It contains the basics for building a Shopify app.
+This is a template for building a [Shopify app](https://shopify.dev/docs/apps/getting-started) using PHP and React. It contains the basics for building a Shopify app.
 
 Rather than cloning this repo, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
 
 ## Benefits
 
-Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app using this template.
+Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/docs/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app using this template.
 
 The PHP app template comes with the following out-of-the-box functionality:
 
@@ -30,7 +30,7 @@ This template combines a number of third party open source tools:
 These third party tools are complemented by Shopify specific tools to ease app development:
 
 -   [Shopify API library](https://github.com/Shopify/shopify-api-php) adds OAuth to the Laravel backend. This lets users install the app and grant scope permissions.
--   [App Bridge React](https://shopify.dev/tools/app-bridge/react-components) adds authentication to API requests in the frontend and renders components outside of the embedded App’s iFrame.
+-   [App Bridge React](https://shopify.dev/docs/tools/app-bridge/react-components) adds authentication to API requests in the frontend and renders components outside of the embedded App’s iFrame.
 -   [Polaris React](https://polaris.shopify.com/) is a powerful design system and component library that helps developers build high quality, consistent experiences for Shopify merchants.
 -   [Custom hooks](https://github.com/Shopify/shopify-frontend-template-react/tree/main/hooks) make authenticated requests to the GraphQL Admin API.
 -   [File-based routing](https://github.com/Shopify/shopify-frontend-template-react/blob/main/Routes.jsx) makes creating new pages easier.
@@ -121,7 +121,7 @@ cd ..
 
 ### Local Development
 
-[The Shopify CLI](https://shopify.dev/apps/tools/cli) connects to an app in your Partners dashboard.
+[The Shopify CLI](https://shopify.dev/docs/apps/tools/cli) connects to an app in your Partners dashboard.
 It provides environment variables, runs commands in parallel, and updates application URLs for easier development.
 
 You can develop locally using your preferred Node.js package manager.
@@ -193,9 +193,9 @@ composer build
 
 ## Hosting
 
-When you're ready to set up your app in production, you can follow [our deployment documentation](https://shopify.dev/apps/deployment/web) to host your app on a cloud provider like [Heroku](https://www.heroku.com/) or [Fly.io](https://fly.io/).
+When you're ready to set up your app in production, you can follow [our deployment documentation](https://shopify.dev/docs/apps/deployment/web) to host your app on a cloud provider like [Heroku](https://www.heroku.com/) or [Fly.io](https://fly.io/).
 
-When you reach the step for [setting up environment variables](https://shopify.dev/apps/deployment/web#set-env-vars), you also need to set the following variables:
+When you reach the step for [setting up environment variables](https://shopify.dev/docs/apps/deployment/web#set-env-vars), you also need to set the following variables:
 
 | Variable          | Secret? | Required |     Value      | Description                                                                         |
 | ----------------- | :-----: | :------: | :------------: | ----------------------------------------------------------------------------------- |
@@ -274,7 +274,7 @@ In the output produced by `cloudflared tunnel` command, you will notice a https 
 2022-11-11T19:57:58Z INF +--------------------------------------------------------------------------------------------+
 ```
 
-In a different terminal window, navigate to your app's root and run one of the following commands (replacing `randomly-generated-hostname` with the Cloudflare tunnel URL copied from the output of `cloudflared` command): 
+In a different terminal window, navigate to your app's root and run one of the following commands (replacing `randomly-generated-hostname` with the Cloudflare tunnel URL copied from the output of `cloudflared` command):
 
 ```shell
 # Using yarn
@@ -287,7 +287,7 @@ pnpm dev --tunnel-url https://randomly-generated-hostname.trycloudflare.com:3000
 
 ## Developer resources
 
--   [Introduction to Shopify apps](https://shopify.dev/apps/getting-started)
--   [App authentication](https://shopify.dev/apps/auth)
--   [Shopify CLI](https://shopify.dev/apps/tools/cli)
+-   [Introduction to Shopify apps](https://shopify.dev/docs/apps/getting-started)
+-   [App authentication](https://shopify.dev/docs/apps/auth)
+-   [Shopify CLI](https://shopify.dev/docs/apps/tools/cli)
 -   [Shopify API Library documentation](https://github.com/Shopify/shopify-api-php/tree/main/docs)

--- a/web/app/Http/Middleware/CspHeader.php
+++ b/web/app/Http/Middleware/CspHeader.php
@@ -13,7 +13,7 @@ class CspHeader
     /**
      * Ensures that the request is setting the appropriate CSP frame-ancestor directive.
      *
-     * See https://shopify.dev/apps/store/security/iframe-protection for more information
+     * See https://shopify.dev/docs/apps/store/security/iframe-protection for more information
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next

--- a/web/app/Lib/Handlers/Gdpr/CustomersDataRequest.php
+++ b/web/app/Lib/Handlers/Gdpr/CustomersDataRequest.php
@@ -11,7 +11,7 @@ use Shopify\Webhooks\Handler;
  * Customers can request their data from a store owner. When this happens,
  * Shopify invokes this webhook.
  *
- * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
+ * https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
  */
 class CustomersDataRequest implements Handler
 {

--- a/web/app/Lib/Handlers/Gdpr/CustomersRedact.php
+++ b/web/app/Lib/Handlers/Gdpr/CustomersRedact.php
@@ -11,7 +11,7 @@ use Shopify\Webhooks\Handler;
  * Store owners can request that data is deleted on behalf of a customer. When
  * this happens, Shopify invokes this webhook.
  *
- * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-redact
+ * https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-redact
  */
 class CustomersRedact implements Handler
 {

--- a/web/app/Lib/Handlers/Gdpr/ShopRedact.php
+++ b/web/app/Lib/Handlers/Gdpr/ShopRedact.php
@@ -11,7 +11,7 @@ use Shopify\Webhooks\Handler;
  * 48 hours after a store owner uninstalls your app, Shopify invokes this
  * webhook.
  *
- * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#shop-redact
+ * https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#shop-redact
  */
 class ShopRedact implements Handler
 {

--- a/web/app/Providers/AppServiceProvider.php
+++ b/web/app/Providers/AppServiceProvider.php
@@ -63,7 +63,7 @@ class AppServiceProvider extends ServiceProvider
          * in the handlers being registered below.
          *
          * More details can be found on shopify.dev:
-         * https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks
+         * https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks
          *
          * Note that you'll only receive these webhooks if your app has the relevant scopes as detailed in the docs.
          */

--- a/web/config/shopify.php
+++ b/web/config/shopify.php
@@ -14,7 +14,7 @@ return [
     | If no payment is found, it starts off the process and sends the merchant to a confirmation URL so that they can
     | approve the purchase.
     |
-    | Learn more about billing in our documentation: https://shopify.dev/apps/billing
+    | Learn more about billing in our documentation: https://shopify.dev/docs/apps/billing
     |
     */
     "billing" => [


### PR DESCRIPTION
### WHY are these changes introduced?

Much of the api and app related content has been moved under /docs on the Shopify Dev site. This updates the links to point to the new locations.

### WHAT is this pull request doing?

See above ☝🏻 