### PR TITLE
Add proxy instructions for non-API routes

### DIFF
--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -28,6 +28,9 @@ use Shopify\Webhooks\Topics;
 | routes are loaded by the RouteServiceProvider within a group which
 | contains the "web" middleware group. Now create something great!
 |
+| If you are adding routes outside of the /api path, remember to also add a
+| proxy rule for them in web/frontend/vite.config.js
+|
 */
 
 Route::fallback(function (Request $request) {


### PR DESCRIPTION
In development mode, the frontend runs on a separate process, and proxies requests to the backend.

By default, that only happens for paths under /api, under the assumption that the app is a single-page application. When adding backend routes outside that path, it's important to remember that we need to add proxy exceptions too, or the FE will take over and render the react app in development.

This PR adds a comment to the routes file to help remind folks about the proxy rules.