### PR TITLE
Add dependabot updates to main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,21 @@
 version: 2
 updates:
-  # Enable version updates for composer - cli_three/web (new template)
+  # Enable version updates for composer - main/web (new template)
   - package-ecosystem: composer
     directory: "/web"
     schedule:
       interval: "daily"
       time: "00:00"
       timezone: "UTC"
-    # Raise PRs for composer updates against the `cli_three` branch
-    target-branch: "cli_three"
+    # Raise PRs for composer updates against the `main` branch
+    target-branch: "main"
     reviewers:
       - Shopify/client-libraries-atc
     labels:
-      - "cli_three"
       - "Composer upgrades"
     open-pull-requests-limit: 100
 
-  # Enable version updates for npm - cli_three/ (new template)
+  # Enable version updates for npm - main/ (new template)
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     # This will be CLI dependencies only
@@ -26,11 +25,10 @@ updates:
       interval: "daily"
       time: "00:00"
       timezone: "UTC"
-    # Raise PRs for version updates to npm against the `cli_three` branch
-    target-branch: "cli_three"
+    # Raise PRs for version updates to npm against the `main` branch
+    target-branch: "main"
     reviewers:
       - Shopify/client-libraries-atc
     # Labels on pull requests for version updates only
     labels:
-      - "cli_three"
       - "npm dependencies"


### PR DESCRIPTION
### WHY are these changes introduced?

The dependabot configuration was copied from the `cli_three` branch and needed to be updated to use/refer to the `main` branch.

### WHAT is this pull request doing?

Change references to `cli_three` to `main` in `dependabot.yml`
