### PR TITLE
Update library version and supported PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
     defaults:
       run:
         working-directory: ./web

--- a/web/composer.json
+++ b/web/composer.json
@@ -2,10 +2,13 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
+    "keywords": [
+        "framework",
+        "laravel"
+    ],
     "license": "UNLICENSED",
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-xml": "*",
         "ext-zip": "*",
         "doctrine/dbal": "^3.1",
@@ -14,7 +17,7 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.12",
         "laravel/tinker": "^2.5",
-        "shopify/shopify-api": "^4.0",
+        "shopify/shopify-api": "^5.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "require-dev": {


### PR DESCRIPTION
### WHY are these changes introduced?

Now that v5.0.0 of the library is out, we need to update the template.

### WHAT is this pull request doing?

Bumping the library dependency to the latest version, and fixing the supported PHP versions in `composer.json` to prevent folks from running into issues on future PHP versions.
