### PR TITLE
Fix app install without host parameter

### DIFF
--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -40,9 +40,11 @@ Route::fallback(function (Request $request) {
         } else {
             return file_get_contents(base_path('frontend/index.html'));
         }
-    } else {
-        return redirect(Utils::getEmbeddedAppUrl($request->query("host", null)) . "/" . $request->path());
     }
+    if ($request->query("host") === null) {
+        return redirect('/api/auth?shop=' . $request->query('shop'));
+    }
+    return redirect(Utils::getEmbeddedAppUrl($request->query("host", null)) . "/" . $request->path());
 })->middleware('shopify.installed');
 
 Route::get('/api/auth', function (Request $request) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Two parameters are expected when accessing the app root URL, bringing more challenges to the installation workflow.

### WHAT is this pull request doing?

Redirecting clients to the base URL with the shop parameter will be enough to initialize the installation.

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
