### PR TITLE
Improving entrypoint.sh to run services in foreground

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -10,10 +10,8 @@ cd /app
 echo "Running database migrations..."
 php artisan migrate --force
 
-echo "Starting nginx server..."
-openrc
-touch /run/openrc/softlevel
-rc-service nginx start
-
 echo "Starting PHP server..."
-php-fpm
+php-fpm &
+
+echo "Starting nginx server..."
+nginx -g 'daemon off;'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Running Docker on Heroku or locally with the previous entrypoint.sh we cannot access the container's terminal since it's not running the services in the foreground.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

I'm running php-fpm and nginx in the background, allowing easy access to the container's terminal when using Heroku or the local environment.

In a Docker environment, it's better to avoid using init systems like OpenRC and instead to start the main process of the container (in this case, nginx or php-fpm) directly in the foreground. That's why it's more common to see nginx -g 'daemon off;' or php-fpm as the command to start the container. This is because Docker itself takes over many of the roles of an init system.

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
