### PR TITLE
chore: Add access control headers for embedded apps

### DIFF
--- a/web/app/Http/Kernel.php
+++ b/web/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\AccessControlHeaders::class,
     ];
 
     /**

--- a/web/app/Http/Middleware/AccessControlHeaders.php
+++ b/web/app/Http/Middleware/AccessControlHeaders.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Shopify\Context;
+
+class AccessControlHeaders
+{
+    /**
+     * Ensures that Access Control Headers are set for embedded apps.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (Context::$IS_EMBEDDED_APP) {
+
+            /** @var Response $response */
+            $response = $next($request);
+
+            $response->headers->set("Access-Control-Allow-Origin", "*");
+            $response->headers->set("Access-Control-Allow-Header", "Authorization");
+            $response->headers->set("Access-Control-Expose-Headers", 'X-Shopify-API-Request-Failure-Reauthorize-Url');
+
+            return $response;
+        }
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Embedded apps need to set certain headers to ensure they can run in an iframe and receive requests from extensions.
 
### WHAT is this pull request doing?

This PR checks if the app is embedded and if so, sets the following headers for all responses:

- `Access-Control-Allow-Origin`
- `Access-Control-Allow-Headers`
- `Access-Control-Expose-Headers`

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [x] I have made changes to the `README.md` file and other related documentation, if applicable (N/A)
