### PR TITLE
[WIP] [Feature] Implement custom auth guard for Shopify sessions and enable unit and feature testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.0"
           - "8.1"
           - "8.2"
     defaults:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Open the URL generated in your console. Once you grant permission to the app, yo
 
 ### Application Storage
 
-This template uses [Laravel's Eloquent framework](https://laravel.com/docs/9.x/eloquent) to store Shopify session data.
+This template uses [Laravel's Eloquent framework](https://laravel.com/docs/10.x/eloquent) to store Shopify session data.
 It provides migrations to create the necessary tables in your database, and it stores and loads session data from them.
 
 The database that works best for you depends on the data your app needs and how it is queried.

--- a/web/app/Http/Kernel.php
+++ b/web/app/Http/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,

--- a/web/app/Http/Middleware/TrustProxies.php
+++ b/web/app/Http/Middleware/TrustProxies.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use Fideloper\Proxy\TrustProxies as Middleware;
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 
 class TrustProxies extends Middleware

--- a/web/app/Lib/ShopifyGuard.php
+++ b/web/app/Lib/ShopifyGuard.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Lib;
+
+use Illuminate\Auth\GuardHelpers;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\UserProvider;
+use Shopify\Auth\Session;
+use Shopify\Utils;
+
+class ShopifyGuard implements Guard
+{
+    use GuardHelpers;
+
+    /**
+     * The Shopify session instance.
+     *
+     * @var \Shopify\Auth\Session
+     */
+    protected Session $session;
+
+    /**
+     * The user provider fetches stored Shopify sessions.
+     *
+     * @var \Illuminate\Contracts\Auth\UserProvider
+     */
+    protected UserProvider $provider;
+
+    /**
+     * Create a new authentication guard for Shopify sessions.
+     *
+     * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
+     */
+    public function __construct(UserProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Get the current Shopify session.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function user()
+    {
+        if (! is_null($this->session)) {
+            return $this->session;
+        }
+
+        $request = request();
+
+        if (! $request->hasHeader('Authorization')) {
+            return;
+        }
+
+        $shopifySession = Utils::loadCurrentSession(
+            $request->header(),
+            $request->cookie(),
+            false
+        );
+
+        if (is_null($shopifySession)) {
+            return;
+        }
+
+        $this->session = $this->provider->retrieveById($shopifySession->getId());
+
+        return $this->session;
+    }
+
+    /**
+     * Validate a user's credentials.
+     *
+     * Credentials are validated through Shopify sessions so we can bypass the
+     * need to validate.
+     *
+     * @param  array  $credentials
+     * @return bool
+     */
+    public function validate(array $credentials = [])
+    {
+        return true;
+    }
+
+    /**
+     * Via remember is disabled for Shopify sessions.
+     *
+     * @return bool
+     */
+    public function viaRemember()
+    {
+        return false;
+    }
+}

--- a/web/app/Models/Session.php
+++ b/web/app/Models/Session.php
@@ -3,9 +3,49 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 
-class Session extends Model
+class Session extends Authenticatable
 {
     use HasFactory;
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = ['access_token'];
+
+    /**
+     * Disable "remember me" compatibility.
+     *
+     * @var null
+     */
+    protected $rememberTokenName = null;
+
+    /**
+     * The non-primary key value that is used to identify a unique session.
+     *
+     * Normally, for a user User model, this would be something like "email",
+     * however, the equivalent for sessions is the session_id column.
+     *
+     * @return string
+     */
+    public function getAuthIdentifierName()
+    {
+        return 'session_id';
+    }
+
+    /**
+     * Sessions do not have passwords, they have access tokens instead.
+     *
+     * This is the functional equivalent of a password in the context of
+     * Shopify sessions.
+     *
+     * @return string
+     */
+    public function getAuthPassword()
+    {
+        return 'access_token';
+    }
 }

--- a/web/app/Providers/AuthServiceProvider.php
+++ b/web/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use App\Lib\ShopifyGuard;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
@@ -25,6 +28,8 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+        Auth::extend('shopify', function (Application $app, string $name, array $config) {
+            return new ShopifyGuard(Auth::createUserProvider($config['provider']));
+        });
     }
 }

--- a/web/composer.json
+++ b/web/composer.json
@@ -2,31 +2,28 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The Laravel Framework.",
-    "keywords": [
-        "framework",
-        "laravel"
-    ],
+    "keywords": ["framework", "laravel"],
     "license": "UNLICENSED",
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "ext-xml": "*",
         "ext-zip": "*",
-        "doctrine/dbal": "^3.1",
-        "fideloper/proxy": "^4.4",
-        "fruitcake/laravel-cors": "^3.0",
-        "guzzlehttp/guzzle": "^7.0.1",
-        "laravel/framework": "^8.12",
-        "laravel/tinker": "^2.5",
+        "doctrine/dbal": "^3.0",
+        "guzzlehttp/guzzle": "^7.2",
+        "laravel/framework": "^10.0",
+        "laravel/sanctum": "^3.2",
+        "laravel/tinker": "^2.8",
         "shopify/shopify-api": "^5.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "require-dev": {
-        "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
-        "laravel/sail": "^1.0.1",
-        "mockery/mockery": "^1.4.2",
-        "nunomaduro/collision": "^5.0",
-        "phpunit/phpunit": "^9.3.3"
+        "laravel/pint": "^1.0",
+        "laravel/sail": "^1.18",
+        "mockery/mockery": "^1.4.4",
+        "nunomaduro/collision": "^7.0",
+        "phpunit/phpunit": "^10.1",
+        "spatie/laravel-ignition": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -68,8 +65,12 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "php-http/discovery": true
+        }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/web/config/auth.php
+++ b/web/config/auth.php
@@ -14,8 +14,7 @@ return [
     */
 
     'defaults' => [
-//        'guard' => 'web',
-//        'passwords' => 'users',
+        'guard' => 'web',
     ],
 
     /*
@@ -36,12 +35,11 @@ return [
     */
 
     'guards' => [
-//        'web' => [
-//            'driver' => 'session',
-//            'provider' => 'users',
-//        ],
-
-    ],
+        'web' => [
+            'driver' => 'shopify',
+            'provider' => 'sessions',
+        ],
+     ],
 
     /*
     |--------------------------------------------------------------------------
@@ -61,52 +59,10 @@ return [
     */
 
     'providers' => [
-//        'users' => [
-//            'driver' => 'eloquent',
-//            'model' => App\Models\User::class,
-//        ],
-
-        // 'users' => [
-        //     'driver' => 'database',
-        //     'table' => 'users',
-        // ],
+        'sessions' => [
+            'driver' => 'eloquent',
+            'model' => \App\Models\Session::class,
+        ],
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Resetting Passwords
-    |--------------------------------------------------------------------------
-    |
-    | You may specify multiple password reset configurations if you have more
-    | than one user table or model in the application and you want to have
-    | separate password reset settings based on the specific user types.
-    |
-    | The expire time is the number of minutes that the reset token should be
-    | considered valid. This security feature keeps tokens short-lived so
-    | they have less time to be guessed. You may change this as needed.
-    |
-    */
-
-//    'passwords' => [
-//        'users' => [
-//            'provider' => 'users',
-//            'table' => 'password_resets',
-//            'expire' => 60,
-//            'throttle' => 60,
-//        ],
-//    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Password Confirmation Timeout
-    |--------------------------------------------------------------------------
-    |
-    | Here you may define the amount of seconds before a password confirmation
-    | times out and the user is prompted to re-enter their password via the
-    | confirmation screen. By default, the timeout lasts for three hours.
-    |
-    */
-
-//    'password_timeout' => 10800,
 
 ];

--- a/web/config/services.php
+++ b/web/config/services.php
@@ -30,4 +30,9 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'shopify' => [
+        'key' => env('SHOPIFY_API_KEY'),
+        'secret' => env('SHOPIFY_API_SECRET'),
+    ]
+
 ];

--- a/web/tests/CreatesApplication.php
+++ b/web/tests/CreatesApplication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/web/tests/TestCase.php
+++ b/web/tests/TestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests;
+
+use App\Http\Middleware\EnsureShopifyInstalled;
+use App\Http\Middleware\EnsureShopifySession;
+use Firebase\JWT\JWT;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Config;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+
+    /**
+     * Override the actingAs method to inject Shopify specific testing capabilities.
+     *
+     * Disables Shopify middleware and generates a mock Bearer token to successfully
+     * authenticate against Shopify for testing purposes.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param string|null $guard
+     *
+     * @return self
+     */
+    public function actingAs(Authenticatable $session, $guard = null): self
+    {
+        $this->withoutMiddleware([
+            EnsureShopifyInstalled::class,
+            EnsureShopifySession::class
+        ]);
+
+        $shopifySecret = Config::get('services.shopify.secret');
+
+        $token = JWT::encode(['dest' => $session->shop], $shopifySecret, 'HS256');
+
+        return parent::actingAs($session, $guard)->withToken($token);
+    }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #466

Please review the changes and suggest feedback. I am still pending resolving one issue with how to dynamically provide the `isOnline` flag when loading the current Shopify session from the Shopify PHP library. I wanted to submit this now to incorporate feedback sooner before I remove this from being WIP.

Here's why I've decided to introduce these changes:

- **Upgrading from Laravel 8 to Laravel 10**: Laravel 8 has reached end of life https://laravel.com/docs/10.x/releases#support-policy. Upgrading the framework to Laravel 10 makes sure we're using a secure and reliable version of Laravel.
- **Custom auth guard `ShopifyGuard`**: Laravel provides many conveniences around when handling authentication through the framework, but the project in its current state bypasses Laravel's authentication (`config/auth.php` is completely commented out). Not being able to leverage framework benefits hurts developer productivity, causes a lot of code redundancy, and makes testing a pain (if not impossible).
- **Enable testing**: Currently the project has no `tests` directory despite having PHPUnit configured. Developers need to be able to write unit and feature tests. Developers should not have to resort to 100% manual testing. Enabling automated testing would decrease the number of bugs escaping into deployed Shopify apps and result in a better overall brand image.

### WHAT is this pull request doing?

- Creates a custom auth guard called `ShopifyGuard` to return the currently authenticated session.
- `\App\Models\Session` model extends `\Illuminate\Foundation\Auth\User` and implements missing `getAuthIdentifierName` and `getAuthPassword` methods.
- Recreates the `tests` directory commonly found in fresh Laravel installations. The `tests/TestCase.php` class contains an overridden `actingAs` method that additionally injects a mock Authorization Bearer token. It also disables the Shopify middleware to allow requests in feature tests to reach the controller while still returning an authenticated `\App\Models\Session` instance.
- Adds Shopify API key and secret to `config/services.php`.
- Upgrades from Laravel 8 to the latest version of Laravel 10.

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
