### PR TITLE
Fix PHP version in composer.json file

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "UNLICENSED",
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "^8.0",
         "ext-xml": "*",
         "ext-zip": "*",
         "doctrine/dbal": "^3.1",


### PR DESCRIPTION
This PR fixes the PHP version in `composer.json` so it works with any PHP8 version.