### PR TITLE
Change create product route to `POST /api/products`

### DIFF
--- a/web/app/Http/Middleware/VerifyCsrfToken.php
+++ b/web/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,8 @@ class VerifyCsrfToken extends Middleware
      * @var array
      */
     protected $except = [
+        'api/products/count',
+        'api/products',
         'api/graphql',
         'api/webhooks',
     ];

--- a/web/app/Lib/ProductCreator.php
+++ b/web/app/Lib/ProductCreator.php
@@ -7,6 +7,7 @@ namespace App\Lib;
 use App\Exceptions\ShopifyProductCreatorException;
 use Shopify\Auth\Session;
 use Shopify\Clients\Graphql;
+use Shopify\Clients\HttpResponse;
 
 class ProductCreator
 {
@@ -31,13 +32,15 @@ class ProductCreator
                     "variables" => [
                         "input" => [
                             "title" => self::randomTitle(),
-                            "variants" => [["price" => self::randomPrice()]],
                         ]
                     ]
                 ],
             );
 
-            if ($response->getStatusCode() !== 200) {
+
+            $body = HttpResponse::fromResponse($response)->getDecodedBody();
+
+            if ($response->getStatusCode() !== 200 || isset($body["errors"])) {
                 throw new ShopifyProductCreatorException($response->getBody()->__toString(), $response);
             }
         }

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -96,7 +96,7 @@ Route::get('/api/products/count', function (Request $request) {
     return response($result->getDecodedBody());
 })->middleware('shopify.auth');
 
-Route::get('/api/products/create', function (Request $request) {
+Route::post('/api/products', function (Request $request) {
     /** @var AuthSession */
     $session = $request->get('shopifySession'); // Provided by the shopify.auth middleware, guaranteed to be active
 


### PR DESCRIPTION
### WHY are these changes introduced?

We want to perform mutations with a POST instead of a GET.

### WHAT is this pull request doing?

- Changed `GET /api/products/create` to `POST /api/products`
- Point `web/frontend` submodule to the commit which updates `fetch` call https://github.com/Shopify/shopify-frontend-template-react/pull/259
- Added `/api/products` and `/api/products/count` to the `VerifyCsrfToken` middleware's list of excepted paths
- Removed `variants` field from `populateProduct` mutation because it's not valid anymore
- Added a check of errors in the response body in addition to HTTP status code because most GraphQL failures still return HTTP 200 ok


https://github.com/Shopify/shopify-app-template-php/assets/446046/a4b1b1dc-ee39-4d00-a18b-bccc79bc81b5



## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] ~I have added/updated tests for this change~ N/A
- [ ] ~I have made changes to the `README.md` file and other related documentation, if applicable~ N/A
