### PR TITLE
Update the TOML schema

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,3 +1,7 @@
 # This file stores configurations for your Shopify app.
 
+client_id = ""
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_products"


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/6612 we are removing support for the legacy app schema.

### WHAT is this pull request doing?

Update the template to include a default `client_id` and move the scopes under `[access_scopes]` to match the new schema.

That way, old CLI versions and the next one without the legacy schema should work.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-php#add-client-id-to-toml
```

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
